### PR TITLE
TC-193--Update-default-visibility-for-announcements

### DIFF
--- a/config/config-default/views.view.announcements.yml
+++ b/config/config-default/views.view.announcements.yml
@@ -390,44 +390,6 @@ display:
             operator_limit_selection: false
             operator_list: {  }
           group: 1
-        field_display_on_all_pages_value:
-          id: field_display_on_all_pages_value
-          table: node__field_display_on_all_pages
-          field: field_display_on_all_pages_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '0'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
@@ -541,6 +503,50 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: boolean
+        field_specific_visibility_target_id:
+          id: field_specific_visibility_target_id
+          table: node__field_specific_visibility
+          field: field_specific_visibility_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: empty
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: numeric
       filter_groups:
         operator: AND
         groups:


### PR DESCRIPTION
Page-specific visibility is now overwriting the "display on all page" checkbox if not empty.