### PR TITLE
Feature/tc 213  glossify path exclusion module

### DIFF
--- a/config/config-default/block.block.jccglossifypathexclusion.yml
+++ b/config/config-default/block.block.jccglossifypathexclusion.yml
@@ -1,0 +1,26 @@
+uuid: 98c37d39-3961-42a3-a9f3-f8138479ec7b
+langcode: en
+status: true
+dependencies:
+  module:
+    - jcc_glossify_path_exclude
+    - system
+  theme:
+    - jcc_base
+id: jccglossifypathexclusion
+theme: jcc_base
+region: content
+weight: 0
+provider: null
+plugin: glossifypathexclusion
+settings:
+  id: glossifypathexclusion
+  label: 'JCC Glossify Path exclusion'
+  provider: jcc_glossify_path_exclude
+  label_display: '0'
+visibility:
+  request_path:
+    id: request_path
+    pages: '*'
+    negate: true
+    context_mapping: {  }

--- a/config/config-default/core.extension.yml
+++ b/config/config-default/core.extension.yml
@@ -76,6 +76,7 @@ module:
   jcc_book_navigation: 0
   jcc_ckeditor: 0
   jcc_featured_links: 0
+  jcc_glossify_path_exclude: 0
   jcc_ical: 0
   jcc_media_formatter: 0
   jcc_tc_migration: 0

--- a/web/modules/custom/jcc_glossify_path_exclude/jcc_glossify_path_exclude.info.yml
+++ b/web/modules/custom/jcc_glossify_path_exclude/jcc_glossify_path_exclude.info.yml
@@ -1,0 +1,5 @@
+name: JCC glossify path exclude
+type: module
+description: Include the "glossifypathexclusion" block anywhere you want glossary items to be hidden.
+core: 8.x
+package: Custom

--- a/web/modules/custom/jcc_glossify_path_exclude/jcc_glossify_path_exclude.module
+++ b/web/modules/custom/jcc_glossify_path_exclude/jcc_glossify_path_exclude.module
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Contains jcc_glossify_path_exclude.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+function jcc_glossify_path_exclude_preprocess_html(&$variables) {
+  $block = Drupal\block\Entity\Block::load('jccglossifypathexclusion');
+  if ($block && $block->access('view')) {
+    $variables['attributes']['class'][] = 'no-glossify';
+  }
+}

--- a/web/modules/custom/jcc_glossify_path_exclude/src/Plugin/Block/JccGlossifyPathsExclude.php
+++ b/web/modules/custom/jcc_glossify_path_exclude/src/Plugin/Block/JccGlossifyPathsExclude.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\jcc_glossify_path_exclude\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ *
+ * @Block(
+ *   id = "glossifypathexclusion",
+ *   admin_label = @Translation("JCC Glossify Path exclusion"),
+ *   category = "JCC custom path exclusion module"
+ * )
+ */
+class JccGlossifyPathsExclude extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return [];
+  }
+
+}

--- a/web/themes/custom/jcc_base/src/sass/components/glossify/_glossify.scss
+++ b/web/themes/custom/jcc_base/src/sass/components/glossify/_glossify.scss
@@ -5,3 +5,17 @@
   color: #555555;
   text-transform: none;
 }
+
+body.no-glossify {
+  .jcc-tooltip {
+    background-color: transparent !important;
+    span{
+      display:none !important;
+    }
+  }
+  .jcc-hero--has-background-color--dark {
+    .jcc-tooltip{
+      color: #ffffff;
+    }
+  }
+}


### PR DESCRIPTION
Custom module which creates an empty block.
Anywhere this block is present a "no-glossify" class is added to the body classes. (Whitelist/Blacklist work natively with the block visibility system)