### PR TITLE
feature/TC-307 move date and categories

### DIFF
--- a/web/themes/custom/jcc_base/src/sass/components/views/_news-list.scss
+++ b/web/themes/custom/jcc_base/src/sass/components/views/_news-list.scss
@@ -3,16 +3,15 @@
   padding-top: 0 !important;
 }
 
-.date_tags {
+.created {
+  margin-top: -10px;
+  width: 200px;
+}
+
+.teaser-text {
   margin-top: 10px;
+}
 
-  .created {
-    float: left;
-    width: 200px;
-  }
-
-  .tags {
-    float: right;
-    width: 400px;
-  }
+.tags {
+    margin-top: 10px;
 }

--- a/web/themes/custom/jcc_base/templates/views/views-view-unformatted--news--page.html.twig
+++ b/web/themes/custom/jcc_base/templates/views/views-view-unformatted--news--page.html.twig
@@ -72,8 +72,14 @@
             {% set title = row.content['#node'].title.value %}
 
             {% set excerpt %}
+              <div class="created">
+                {{ row.content['#node'].created.value|date(format="F j, Y" ) }}
+              </div>
+
               {% if row.content['#node'].body.value %}
-                {{ row.content['#node'].body.value|striptags|length > 600 ? row.content['#node'].body.value|striptags|slice(0, 600) ~ '...' : row.content['#node'].body.value|striptags }}
+                <div class="teaser-text">
+                  {{ row.content['#node'].body.value|striptags|length > 600 ? row.content['#node'].body.value|striptags|slice(0, 600) ~ '...' : row.content['#node'].body.value|striptags }}
+                </div>
               {% endif %}
 
               {% set division = row.content['#node'].field_division[0] %}
@@ -81,16 +87,11 @@
               {% set tags = row.content['#node'].field_tags[0] %}
               {% set topics = row.content['#node'].field_topics[0] %}
 
-              <div class="date_tags">
-                <div class="created">
-                  {{ row.content['#node'].created.value|date(format="F j, Y" ) }}
+              {% if division or subject_matter or tags or topics %}
+                <div class="tags">
+                  Categories: {{ division|view }} {{ subject_matter|view }} {{ tags|view }} {{ topics|view }}
                 </div>
-                {% if division or subject_matter or tags or topics %}
-                  <div class="tags">
-                    {{ division|view }} {{ subject_matter|view }} {{ tags|view }} {{ topics|view }}
-                  </div>
-                {% endif %}
-              </div>
+              {% endif %}
             {% endset %}
 
             {% set url = path('entity.node.canonical', {'node': row.content['#node'].nid[0].value}) %}


### PR DESCRIPTION
Based on Penne's feedback, moving date to under title and moving categories to left where date was.