### PR TITLE
feature/WSGEN-1027--Newsroom-Phone-Number-Format

### DIFF
--- a/config/config-newsroom/core.entity_form_display.node.person.default.yml
+++ b/config/config-newsroom/core.entity_form_display.node.person.default.yml
@@ -237,7 +237,8 @@ content:
     region: content
   field_metatag:
     weight: 17
-    settings: {  }
+    settings:
+      sidebar: true
     third_party_settings: {  }
     type: metatag_firehose
     region: content
@@ -261,7 +262,7 @@ content:
   field_phone:
     weight: 21
     settings:
-      placeholder: ''
+      placeholder: 415-555-1212
     third_party_settings: {  }
     type: telephone_default
     region: content


### PR DESCRIPTION
The phone number format is not obvious in Person so I've added placeholder phone number to provide context to format.  This should satisfy the issue.  Currently the Newsroom is not even using the phone number so it is rather moot but they may use it in a future phase so this should be useful whenever that happens.