### PR TITLE
TCI-516: Adding subpages to alert autocomplete

### DIFF
--- a/config/config-inyo/field.field.node.alert.field_node_reference.yml
+++ b/config/config-inyo/field.field.node.alert.field_node_reference.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_node_reference
     - node.type.alert
     - node.type.landing_page
+    - node.type.subpage
 id: node.alert.field_node_reference
 field_name: field_node_reference
 entity_type: node
@@ -21,6 +22,7 @@ settings:
   handler_settings:
     target_bundles:
       landing_page: landing_page
+      subpage: subpage
     sort:
       field: _none
     auto_create: false


### PR DESCRIPTION
Adding subpages to the "specific pages" entity reference field, with this all the landing pages and subpages will be shown in autocomplete.