### PR TITLE
TCI-582 Snippets hotfix

### DIFF
--- a/web/themes/custom/jcc_components/templates/media/media--snippet.html.twig
+++ b/web/themes/custom/jcc_components/templates/media/media--snippet.html.twig
@@ -10,7 +10,7 @@
  * @see template_preprocess_media()
  */
 #}
-<article{{ attributes.addClass('usa-prose') }}>
+<article class="usa-prose">
   {{ title_suffix.contextual_links }}
   {% if content %}
     {{ content }}


### PR DESCRIPTION
- Remove "attributes" so ckeditor can't use alignment classes (i.e. align-center), which causes editor confusion.