### PR TITLE
TCI-683 :: Full Width Hero w/ No Aside Content

### DIFF
--- a/web/themes/custom/jcc_components/templates/paragraph/paragraph--hero.html.twig
+++ b/web/themes/custom/jcc_components/templates/paragraph/paragraph--hero.html.twig
@@ -40,12 +40,12 @@
 #}
 
 {% set parent_type = paragraph.getParentEntity().getType() %}
-{% set variant = paragraph.field_variant.value|json_decode %}
+{% set no_aside = content.field_subheading.0 is empty and content.field_aside.0 is empty and content.field_link.0 is empty %}
 {% set background = parent_type == 'landing_page' ? 'alt' : 'default' %}
 
 {% include "@molecules/hero/hero.twig" with {
   hero: {
-    layout: variant.hero,
+    layout: no_aside == 1 ? 'full-main' : hero.variant,
     background: background,
     main: {
       title: content.field_heading.0|render,

--- a/web/themes/custom/jcc_components/templates/paragraph/paragraph--hero.html.twig
+++ b/web/themes/custom/jcc_components/templates/paragraph/paragraph--hero.html.twig
@@ -40,12 +40,14 @@
 #}
 
 {% set parent_type = paragraph.getParentEntity().getType() %}
+{% set variant = paragraph.field_variant.value|json_decode %}
+{# Force layout to full width if "aside" fields are empty. #}
 {% set no_aside = content.field_subheading.0 is empty and content.field_aside.0 is empty and content.field_link.0 is empty %}
 {% set background = parent_type == 'landing_page' ? 'alt' : 'default' %}
 
 {% include "@molecules/hero/hero.twig" with {
   hero: {
-    layout: no_aside == 1 ? 'full-main' : hero.variant,
+    layout: no_aside ? 'full-main' : variant.hero,
     background: background,
     main: {
       title: content.field_heading.0|render,


### PR DESCRIPTION
# Pull Request

Closes Issue #TCI-683

## Issue Description

The Hero's page title should run the full width of the container when there is no aside content available.

## Summary of Changes

- Adjust Hero Paragraph template to utilize a `no_aside` var to determine if there's aside content available
- Set Hero's layout based on new variable

## Testing Instructions

- Visit Drupal Site
- Visit Content with Hero Paragraph
- [ ] Content displays full width when no aside content is present
- [ ] Content with aside content can still use variants to update or change display