### PR TITLE
TCI-777: update templates, revise js for table

### DIFF
--- a/web/modules/custom/jcc_custom/js/jcc-custom-tableadapt.js
+++ b/web/modules/custom/jcc_custom/js/jcc-custom-tableadapt.js
@@ -9,7 +9,8 @@
 
   Drupal.behaviors.jccTableAdapt = {
     attach: function (context, settings) {
-      $('.jcc-section table', context).each( function() {
+      var $formTable = $('.jcc-form', context).siblings('table');
+      $('.jcc-section table', context).add($formTable).each( function() {
         let $currentTable = $(this);
         let $headers = $currentTable.find('thead th');
 

--- a/web/themes/custom/jcc_components/templates/paragraph/paragraph--webform.html.twig
+++ b/web/themes/custom/jcc_components/templates/paragraph/paragraph--webform.html.twig
@@ -48,6 +48,5 @@
       lead: paragraph.field_lead.value ? content.field_lead,
     },
     content: content.field_webform,
-    classes: ['usa-paragraph-webform']
   }
 } %}

--- a/web/themes/custom/jcc_components/templates/paragraph/paragraph.html.twig
+++ b/web/themes/custom/jcc_components/templates/paragraph/paragraph.html.twig
@@ -44,15 +44,15 @@
 {% block paragraph %}
   {% block content %}
     {% include "@molecules/section/section.twig" with {
-    section: {
-      classes: custom_class,
-      heading: {
-        title: paragraph.field_heading.value ? paragraph.field_heading.value,
-        lead: paragraph.field_lead.value ? content.field_lead,
-      },
-      content: content|without('field_heading', 'field_lead'),
-      classes: ['usa-paragraph-content']
-      }
-    } %}
+      section: {
+        classes: custom_class,
+        heading: {
+          title: paragraph.field_heading.value ? paragraph.field_heading.value,
+          lead: paragraph.field_lead.value ? content.field_lead,
+        },
+        content: content|without('field_heading', 'field_lead'),
+        }
+      } 
+    %}
   {% endblock content %}
 {% endblock paragraph %}


### PR DESCRIPTION
- Update Templates
- Revise JS for form table siblings*

I think this JS override should be removed in preference for a non-JS solution to apply markup. However I'm not familiar enough with the code base to make that change absent VRT.