### PR TITLE
TCI-849 :: Remove HTML Embed from Editor

### DIFF
--- a/config/config-inyo/core.extension.yml
+++ b/config/config-inyo/core.extension.yml
@@ -21,7 +21,6 @@ module:
   ckeditor: 0
   ckeditor_a11ychecker: 0
   ckeditor_balloonpanel: 0
-  ckeditor_inserthtml: 0
   color: 0
   colorbox: 0
   components: 0

--- a/config/config-inyo/editor.editor.body.yml
+++ b/config/config-inyo/editor.editor.body.yml
@@ -7,7 +7,7 @@ dependencies:
   module:
     - ckeditor
 _core:
-  default_config_hash: v4igbxxlN20j7bKKp4GSEjlfWks1qXYTiLDKIu0WdxI
+  default_config_hash: wOqpwOjPyr3ziKYELH6Wgk3DBL1ngClIpU9xyrdHN8E
 format: body
 editor: ckeditor
 settings:
@@ -39,7 +39,6 @@ settings:
         -
           name: Tools
           items:
-            - inserthtml4x
             - HorizontalRule
             - Table
             - Source

--- a/config/config-inyo/field.field.node.landing_page.field_components.yml
+++ b/config/config-inyo/field.field.node.landing_page.field_components.yml
@@ -23,7 +23,7 @@ third_party_settings:
   tmgmt_content:
     excluded: false
 _core:
-  default_config_hash: u26Rd3GHTb0maRCYjSwna8vE_iOgOnJcrkhNdb-nYaA
+  default_config_hash: 2s-vtSaHxKpeIqmcUe_Zr-k2pQElT1-zt4uAYzFvPT4
 id: node.landing_page.field_components
 field_name: field_components
 entity_type: node

--- a/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/editor.editor.body.yml
+++ b/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/editor.editor.body.yml
@@ -7,7 +7,7 @@ dependencies:
   module:
     - ckeditor
 _core:
-  default_config_hash: v4igbxxlN20j7bKKp4GSEjlfWks1qXYTiLDKIu0WdxI
+  default_config_hash: wOqpwOjPyr3ziKYELH6Wgk3DBL1ngClIpU9xyrdHN8E
 format: body
 editor: ckeditor
 settings:

--- a/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/editor.editor.body.yml
+++ b/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/editor.editor.body.yml
@@ -39,7 +39,6 @@ settings:
         -
           name: Tools
           items:
-            - inserthtml4x
             - HorizontalRule
             - Table
             - Source

--- a/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/field.field.node.landing_page.field_components.yml
+++ b/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/field.field.node.landing_page.field_components.yml
@@ -23,7 +23,7 @@ third_party_settings:
   tmgmt_content:
     excluded: false
 _core:
-  default_config_hash: u26Rd3GHTb0maRCYjSwna8vE_iOgOnJcrkhNdb-nYaA
+  default_config_hash: 2s-vtSaHxKpeIqmcUe_Zr-k2pQElT1-zt4uAYzFvPT4
 id: node.landing_page.field_components
 field_name: field_components
 entity_type: node


### PR DESCRIPTION
Removes the `inserthtml4x` option from the Body Editor.