### PR TITLE
TCI-960: Add empty check on entity in utility function.

### DIFF
--- a/web/themes/custom/jcc_components/includes/node.inc
+++ b/web/themes/custom/jcc_components/includes/node.inc
@@ -269,7 +269,8 @@ function jcc_components_node_document(array &$variables, NodeInterface $node) {
   // Contextual edit media file option.
   if (isset($node->field_media->target_id)) {
     $media = Media::load($node->field_media->target_id);
-    $variables['edit_option'] = _jcc_components_can_edit_entity($media, t('Edit'));
+
+    $variables['edit_option'] = empty($media) ? NULL : _jcc_components_can_edit_entity($media, t('Edit'));
   }
 
   // Ensure date range field timezone.

--- a/web/themes/custom/jcc_components/includes/utilities.inc
+++ b/web/themes/custom/jcc_components/includes/utilities.inc
@@ -5,17 +5,27 @@
  * Functions for views processing.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\user\Entity\User;
 
 /**
  * Helper function for $entity edit contextual link.
+ *
+ * @param Drupal\Core\Entity\EntityInterface $entity
+ *   The entity to check for access.
+ * @param string $cta
+ *   The text string for the edit link.
+ *
+ * @return mixed
+ *   NULL or a render array.
  */
-function _jcc_components_can_edit_entity($entity, $cta) {
+function _jcc_components_can_edit_entity(EntityInterface $entity, string $cta) {
   $user = User::load(\Drupal::currentUser()->id());
-  $can_edit = $entity->access('update', $user);
+  $can_edit = empty($entity) ? FALSE : $entity->access('update', $user);
   $edit = NULL;
+
   if ($can_edit) {
     $url = Url::fromRoute('entity.' . $entity->getEntityTypeId() . '.edit_form', [$entity->getEntityTypeId() => $entity->id()]);
     $edit = Link::fromTextAndUrl($cta, $url);
@@ -30,5 +40,5 @@ function _jcc_components_can_edit_entity($entity, $cta) {
     $edit['#attributes'] = ['aria-label' => ['Edit ' . $title]];
   }
 
-  return render($edit);
+  return \Drupal::service('renderer')->render($edit);
 }


### PR DESCRIPTION
This function was causing cron to fail on Stanislaus. I'm not sure why it would even run on cron but it failed because no entity value was passed to the function. This function and the ones that call it seem to duplicate core functionality.

Corrected Drupal standards.