### PR TITLE
TCI-980: Set file migration to rename duplicate file names instead of…

### DIFF
--- a/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/migrate_plus.migration.forms_file.yml
+++ b/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/migrate_plus.migration.forms_file.yml
@@ -72,7 +72,7 @@ process:
       source:
         - '@pseudo_decoded_url'
         - '@pseudo_destination_path'
-      file_exists: replace
+      file_exists: rename
       move: false
 destination:
   plugin: 'entity:file'


### PR DESCRIPTION
… replace.

There are cases when different files from different departments have the same file name. This lead to multiple media entities linking to the same file of that name.