### PR TITLE
Feature/tci 984  editor control request

### DIFF
--- a/config/config-inyo/editor.editor.body.yml
+++ b/config/config-inyo/editor.editor.body.yml
@@ -7,7 +7,7 @@ dependencies:
   module:
     - ckeditor
 _core:
-  default_config_hash: sMkpZvyDo5C5zKyvQy-vzOWAe67MzpTRGf5LzSLYvzg
+  default_config_hash: BJfAvs1s9ADMETQhFnmr8rpGRmxHVcndhMduVMyBpmc
 format: body
 editor: ckeditor
 settings:
@@ -20,7 +20,11 @@ settings:
             - Bold
             - Italic
             - Format
+            - Strike
+            - Superscript
+            - Subscript
             - Styles
+            - RemoveFormat
         -
           name: Links
           items:
@@ -47,17 +51,8 @@ settings:
     drupallink:
       linkit_enabled: true
       linkit_profile: default
-    language:
-      language_list: un
     stylescombo:
-      styles: "blockquote.blockquote--callout|Callout\r\nblockquote.blockquote--italic|Italic\r\nblockquote.blockquote--box|Box\r\nblockquote.blockquote--alert--warning|Warning alert\r\nblockquote.blockquote--alert--error|Error alert\r\nblockquote.blockquote--alert--success|Success alert\r\nblockquote.blockquote--alert--info|Info alert\r\na.jcc-button--primary|Primary\r\na.jcc-button--cta-link|CTA Link"
-    video_embed:
-      defaults:
-        children:
-          autoplay: false
-          responsive: true
-          width: '854'
-          height: '480'
+      styles: "blockquote.blockquote--callout|Callout\r\nblockquote.blockquote--italic|Italic\r\nblockquote.blockquote--box|Box\r\nblockquote.blockquote--alert--warning|Warning alert\r\nblockquote.blockquote--alert--error|Error alert\r\nblockquote.blockquote--alert--success|Success alert\r\nblockquote.blockquote--alert--info|Info alert\r\na.jcc-button--primary|Primary\r\na.jcc-button--cta-link|CTA Link\r\na.twitter-timeline|Twitter Timeline"
 image_upload:
   status: true
   scheme: public

--- a/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/editor.editor.body.yml
+++ b/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/editor.editor.body.yml
@@ -17,7 +17,11 @@ settings:
             - Bold
             - Italic
             - Format
+            - Strike
+            - Superscript
+            - Subscript
             - Styles
+            - RemoveFormat
         -
           name: Links
           items:


### PR DESCRIPTION
Hi, 
Here, I am exporting Body text editor formatting options.
After doing drush config export through the command, its generated below file, 

> trialcourt/config/config-inyo/editor.editor.body.yml

Formatting options content 
<img width="265" alt="Screen Shot 2023-01-06 at 8 01 44 PM" src="https://user-images.githubusercontent.com/11643534/211126473-3e16e098-acf7-49ad-ba4f-699c88212743.png">

 
I have copied this formatting options from above file to this file 

> trialcourt/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/editor.editor.body.yml

I just wanted to let you know that I have created this branch from _Master_.