### PR TITLE
TCI-1042--anchor-link-editor-module-enabled

### DIFF
--- a/config/config-lassen/core.extension.yml
+++ b/config/config-lassen/core.extension.yml
@@ -6,6 +6,7 @@ module:
   admin_toolbar_links_access_filter: 0
   admin_toolbar_tools: 0
   allowed_formats: 0
+  anchor_link: 0
   autocomplete_deluxe: 0
   automated_cron: 0
   ban: 0


### PR DESCRIPTION
Anchor link does not exist in Lassen, Anchor link module enabled.