### PR TITLE
[LWR-143] - [fix] -- Setup paragraph body template to use storybook Body component

### DIFF
--- a/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--body.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--body.html.twig
@@ -1,27 +1,9 @@
-{{ attach_library("jcc_storybook/Section") }}
-{{ attach_library("jcc_storybook/Brow") }}
-{{ attach_library("jcc_storybook/Card") }}
+{{ attach_library("jcc_storybook/Body") }}
 
-{% include "@organisms/Section/Section.twig" with {
-  variant: "default",
-  first_component: false,
-  brow_data: {
-    attributes: create_attribute(),
-    variant: "default",
-    part_one: "Brow Example",
-    part_two: "",
-  },
+{% include "@molecules/Body/Body.twig" with {
   heading: content.field_heading,
-  text: content.field_lead,
-  sub_component_template: "Card",
-  sub_component_data: {
-    attributes: create_attribute(),
-    variant: "default",
-    media: false,
-    icon_data: {},
-    heading: content.field_heading,
-    text: content.field_text,
-    button: {},
-  },
-  button_data: {}
+  lead: content.field_lead,
+  content: content.field_text,
+  subheading: content.field_subheading,
+  aside: content.field_aside,
 } %}


### PR DESCRIPTION
[LWR-143]

Setup paragraph body template to use storybook Body component.

**NOTE: This should go in place only when https://github.com/JudicialCouncilOfCalifornia/jcc_storybook/pull/37 has been merged and launched into storybook, Otherwise a template error will occur if a body paragraph is on a page.**