### PR TITLE
[Fix] Updates to some twig files for better output (and better storybook integration

### DIFF
--- a/web/themes/custom/jcc_elevated/includes/paragraph.inc
+++ b/web/themes/custom/jcc_elevated/includes/paragraph.inc
@@ -107,17 +107,21 @@ function jcc_elevated_paragraph_card(array &$variables, ParagraphInterface $para
   }
 
   // Disallows links in text if clickable striped card.
+  $variables['filtered_text'] = NULL;
   $parent = $paragraph->getParentEntity();
-  $cards_sub_variant = $parent->get('field_sub_variant')->value;
-  $cards_sub_variant = substr($cards_sub_variant, strpos($cards_sub_variant, ':'));
-  $cards_sub_variant = preg_replace("/[^a-zA-Z0-9]+/", "", $cards_sub_variant);
-  if ($cards_sub_variant == 'striped' && $paragraph->field_entire_card_clickable->value) {
-    // Allowed tags in minimal editor except <a>.
-    $allowed_tags = '<p><em><strong><u><s><sup><sub><ol><li><ul>';
-    $text = $paragraph->get('field_text')->value;
-    $text = strip_tags($text, $allowed_tags);
-    $variables['filtered_text'] = Markup::create($text);
+  if ($parent->hasField('field_sub_variant')) {
+    $cards_sub_variant = $parent->get('field_sub_variant')->value;
+    $cards_sub_variant = substr($cards_sub_variant, strpos($cards_sub_variant, ':'));
+    $cards_sub_variant = preg_replace("/[^a-zA-Z0-9]+/", "", $cards_sub_variant);
+    if ($cards_sub_variant == 'striped' && $paragraph->field_entire_card_clickable->value) {
+      // Allowed tags in minimal editor except <a>.
+      $allowed_tags = '<p><em><strong><u><s><sup><sub><ol><li><ul>';
+      $text = $paragraph->get('field_text')->value;
+      $text = strip_tags($text, $allowed_tags);
+      $variables['filtered_text'] = Markup::create($text);
+    }
   }
+
 }
 
 /**

--- a/web/themes/custom/jcc_elevated/includes/system.inc
+++ b/web/themes/custom/jcc_elevated/includes/system.inc
@@ -10,7 +10,7 @@
  */
 function jcc_elevated_preprocess_pager(&$variables) {
   // Add the current value into items for easier theming.
-  $variables['items']['current'] = $variables['current'];
+  $variables['items']['current'] = $variables['current'] ?? 0;
 
   if (isset($variables['items']['first']['text'])) {
     // Lock the text value for the first.

--- a/web/themes/custom/jcc_elevated/templates/node/node--alert.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/node/node--alert.html.twig
@@ -1,0 +1,82 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+{{ attach_library("jcc_storybook/Alert") }}
+{{ attach_library("jcc_storybook/Icon") }}
+
+{% include "@molecules/Alert/Alert.twig" with {
+  type: node.field_alert_type.get(0).value|default('info'),
+  dismissible: node.field_toggle.get(0).value|default(false),
+  heading: label,
+  content: [content.body|render],
+  icon_path: base_path ~ 'themes/contrib/jcc_storybook/src/assets/icons.svg',
+} %}

--- a/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--alert.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--alert.html.twig
@@ -6,4 +6,5 @@
   dismissible: false,
   heading: paragraph.field_heading.get(0).value,
   content: content|without('field_variant'),
+  icon_path: base_path ~ 'themes/contrib/jcc_storybook/src/assets/icons.svg',
 } %}

--- a/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--body.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--body.html.twig
@@ -1,9 +1,9 @@
 {{ attach_library("jcc_storybook/Body") }}
 
 {% include "@molecules/Body/Body.twig" with {
-  heading: content.field_heading,
-  lead: content.field_lead,
-  content: content.field_text,
-  subheading: content.field_subheading,
-  aside: content.field_aside,
+  heading: content.field_heading|render,
+  lead: content.field_lead|render,
+  content: content.field_text|render,
+  subheading: content.field_subheading|render,
+  aside: content.field_aside|render,
 } %}

--- a/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--card.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--card.html.twig
@@ -4,8 +4,8 @@
 
 {# Card variant selection set by parent #}
 {% set paragraph_parent = paragraph.getParentEntity() %}
-{% if paragraph_parent %}
-  {% set cards_sub_variant = paragraph_parent.field_sub_variant.value|json_decode %}
+{% if paragraph_parent.hasField('field_sub_variant') %}
+  {% set cards_sub_variant = paragraph_parent.field_sub_variant.value|json_decode|default([]) %}
 {% endif %}
 
 {#  Media if in use for non-striped card #}
@@ -42,6 +42,6 @@
   background: cards_sub_variant.card == 'striped' ? paragraph.field_background.value : null,
   media: media,
   heading: content.field_heading,
-  text: filtered_text ? filtered_text : content.field_text.0,
+  text: filtered_text ?? content.field_text|render,
   button_data: button_data,
 } %}

--- a/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--cards.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--cards.html.twig
@@ -3,7 +3,11 @@
 
 {# Only allow elevated card variants #}
 {% set card_variant = 'default' %}
-{% set cards_sub_variant = paragraph.field_sub_variant.value|json_decode %}
+{% set cards_sub_variant = [] %}
+
+{% if paragraph_parent.hasField('field_sub_variant') %}
+  {% set cards_sub_variant = paragraph.field_sub_variant.value|json_decode %}
+{% endif %}
 {% if cards_sub_variant.card == 'striped' or cards_sub_variant == 'bordered-center' %}
   {% set card_variant = cards_sub_variant.card %}
 {% endif %}

--- a/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--section.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--section.html.twig
@@ -21,10 +21,10 @@
 {% include "@organisms/Section/Section.twig" with {
   variant: paragraph.field_section_background.get(0).value|default('default'),
   brow_data: {
-    part_one: content.field_brow,
+    part_one: content.field_brow|render,
   },
-  heading: content.field_heading,
-  text: content.field_lead,
+  heading: content.field_heading|render,
+  text: content.field_lead|render,
   sub_component_data: content.field_components|render,
   button_data: button_data,
   background_image_url: background_url,

--- a/web/themes/custom/jcc_elevated/templates/system/pager.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/system/pager.html.twig
@@ -37,5 +37,6 @@
 {% if items %}
   {% include "@molecules/Pager/Pager.twig" with {
     variant: 'default',
+    icon_path: base_path ~ 'themes/contrib/jcc_storybook/src/assets/icons.svg',
   } %}
 {% endif %}

--- a/web/themes/custom/jcc_elevated/templates/system/status-messages.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/system/status-messages.html.twig
@@ -39,6 +39,7 @@
       type: type,
       dismissible: 'true',
       content: messages,
+      icon_path: base_path ~ 'themes/contrib/jcc_storybook/src/assets/icons.svg',
     } %}
 
     {% if type == 'error' %}


### PR DESCRIPTION
[Fix] 

Updates to some twig files for better output (and better storybook integration) and address some php notices/warnings.

- Rendering output in body and section paragraphs to go along with the 'is not empty' checks on the storybook twig components. 
- Added a field_sub_variant check on cards and card paragraphs to help address some php warnings and notices. 
- Added icon path to data for Alerts and Pagers to help initiate icons.
- Added node alert template with Alert component integration.