### PR TITLE
[fix] Cleanup of css issues.

### DIFF
--- a/web/modules/custom/jcc_custom/css/gin-elevated.css
+++ b/web/modules/custom/jcc_custom/css/gin-elevated.css
@@ -1,12 +1,20 @@
 
 /* Specific overrides for drupal nav tabs */
 /* This removes the weird black lines that appear on view/edit/delete tabs */
-.is-horizontal .nav-tabs__tabs--primary:before {
+.nav-tabs .is-horizontal .nav-tabs__tabs--primary:before {
   border: 0;
 }
 
-.nav-tabs__tabs--primary .nav-tabs__link {
+.nav-tabs .nav-tabs__tabs--primary .nav-tabs__link {
   border: 0;
+}
+
+.nav-tabs .is-horizontal .nav-tabs__tabs--primary li .nav-tabs__link {
+  border: 0;
+}
+
+.nav-tabs .is-collapse-enabled .tabs__trigger {
+  margin-inline-end: 1rem;
 }
 
 /* Style for the section background select items (admin side) */
@@ -14,4 +22,37 @@
   padding: .5rem;
   max-width: 30ch;
   border: 1px solid var(--color-base-light-x);
+}
+
+/* Style tweaks for landing and subpage paragraph edit form */
+.js .gin--edit-form .paragraph-type-top {
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-items: center;
+  margin-block-end: 1rem;
+}
+
+.js .gin--edit-form .paragraph-type-title {
+  align-self: center;
+  font-size: 12px;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #828388;
+}
+
+/* External link icons */
+svg.ext,
+svg.mailto {
+  width: calc(var(--s0) + 2px);
+  height: calc(var(--s0) + 2px);
+  padding-right: unset;
+  padding-inline-start: var(--s-5);
+  fill: currentColor;
+  font-weight: 600;
+}
+svg.ext path,
+svg.mailto path {
+  stroke: currentColor;
+  stroke-width: 0;
 }

--- a/web/modules/custom/jcc_custom/jcc_custom.libraries.yml
+++ b/web/modules/custom/jcc_custom/jcc_custom.libraries.yml
@@ -57,4 +57,4 @@ storybook-section:
 gin-elevated:
   css:
     theme:
-      css/gin-elevated.css: {}
+      css/gin-elevated.css: { weight: 50 }

--- a/web/modules/custom/jcc_custom/jcc_custom.module
+++ b/web/modules/custom/jcc_custom/jcc_custom.module
@@ -27,8 +27,9 @@ function jcc_custom_page_attachments(array &$attachments) {
   $is_admin = \Drupal::service('router.admin_context')->isAdminRoute();
   if (!$is_admin) {
     $attachments['#attached']['library'][] = 'jcc_custom/filelink';
-    $attachments['#attached']['library'][] = 'jcc_custom/forms';  
+    $attachments['#attached']['library'][] = 'jcc_custom/forms';
     $attachments['#attached']['library'][] = 'jcc_custom/feedbacksurvey';
+    $attachments['#attached']['library'][] = 'jcc_custom/gin-elevated';
   }
 }
 


### PR DESCRIPTION
Cleanup of css issues for drupal tabs, external link icons, and some tweaks to the gin node edit display.

Sets the gin-elevated theme to later in addition. fixes coloring and sizing of external link svg icons. Styles the paragraph type label on paragraph fields a little cleaner. Applied the border fix for edit tabs on front end.