### PR TITLE
[LWR-219] -- Style and template cleanup and upgrade to storybook tag 0.53.5

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "222a9a0b2775b441eb41ab0926fc9bf3",
+    "content-hash": "1c54e3b56eaccdf9b5b62094bb943166",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -15096,16 +15096,16 @@
         },
         {
             "name": "judicialcouncil/jcc_storybook",
-            "version": "0.53.4",
+            "version": "0.53.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JudicialCouncilOfCalifornia/jcc_storybook.git",
-                "reference": "f68665f0fb771c6e93c7d475933ab91329527dfc"
+                "reference": "976462dc510bf6e58c4581839744104b26c423b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JudicialCouncilOfCalifornia/jcc_storybook/zipball/f68665f0fb771c6e93c7d475933ab91329527dfc",
-                "reference": "f68665f0fb771c6e93c7d475933ab91329527dfc",
+                "url": "https://api.github.com/repos/JudicialCouncilOfCalifornia/jcc_storybook/zipball/976462dc510bf6e58c4581839744104b26c423b9",
+                "reference": "976462dc510bf6e58c4581839744104b26c423b9",
                 "shasum": ""
             },
             "require": {
@@ -15132,7 +15132,7 @@
                 "issues": "https://www.courts.ca.gov/policyadmin-jc.htm",
                 "source": "https://github.com/JudicialCouncilOfCalifornia/jcc_storybook"
             },
-            "time": "2023-06-06T18:11:50+00:00"
+            "time": "2023-06-09T08:58:38+00:00"
         },
         {
             "name": "kint-php/kint",
@@ -23054,5 +23054,5 @@
         "php": ">=7.4"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -15096,16 +15096,16 @@
         },
         {
             "name": "judicialcouncil/jcc_storybook",
-            "version": "0.53.5",
+            "version": "0.53.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JudicialCouncilOfCalifornia/jcc_storybook.git",
-                "reference": "976462dc510bf6e58c4581839744104b26c423b9"
+                "reference": "c9fe68bcfbaf4cd569af060b23bf3550123ed99a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JudicialCouncilOfCalifornia/jcc_storybook/zipball/976462dc510bf6e58c4581839744104b26c423b9",
-                "reference": "976462dc510bf6e58c4581839744104b26c423b9",
+                "url": "https://api.github.com/repos/JudicialCouncilOfCalifornia/jcc_storybook/zipball/c9fe68bcfbaf4cd569af060b23bf3550123ed99a",
+                "reference": "c9fe68bcfbaf4cd569af060b23bf3550123ed99a",
                 "shasum": ""
             },
             "require": {
@@ -15132,7 +15132,7 @@
                 "issues": "https://www.courts.ca.gov/policyadmin-jc.htm",
                 "source": "https://github.com/JudicialCouncilOfCalifornia/jcc_storybook"
             },
-            "time": "2023-06-09T08:58:38+00:00"
+            "time": "2023-06-09T18:55:49+00:00"
         },
         {
             "name": "kint-php/kint",

--- a/web/modules/custom/jcc_custom/jcc_custom.module
+++ b/web/modules/custom/jcc_custom/jcc_custom.module
@@ -10,7 +10,6 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Field\FieldFilteredMarkup;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Url;
 use Drupal\editor\Entity\Editor;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\file\Element\ManagedFile;
@@ -556,10 +555,10 @@ function jcc_custom_field_widget_entity_reference_paragraphs_form_alter(&$elemen
 function jcc_custom_build_menu_tree(array $tree): array {
   $items = [];
   foreach ($tree as $menu_data) {
-    if ($menu_data['url']->toString()) {
+    if (!empty($menu_data['url'])) {
       $items[] = [
         'title' => $menu_data['title'],
-        'url' => !empty($menu_data['url']) ? $menu_data['url'] : Url::fromRoute('<front>'),
+        'url' => !empty($menu_data['url']) ? $menu_data['url'] : '',
         'attributes' => !empty($menu_data['attributes']) ? $menu_data['attributes']->toArray() : [],
         'active' => $menu_data['in_active_trail'],
         'links' => $menu_data['below'] ? jcc_custom_build_menu_tree($menu_data['below']) : [],

--- a/web/modules/custom/jcc_custom/jcc_custom.module
+++ b/web/modules/custom/jcc_custom/jcc_custom.module
@@ -10,6 +10,7 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Field\FieldFilteredMarkup;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\editor\Entity\Editor;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\file\Element\ManagedFile;
@@ -555,13 +556,15 @@ function jcc_custom_field_widget_entity_reference_paragraphs_form_alter(&$elemen
 function jcc_custom_build_menu_tree(array $tree): array {
   $items = [];
   foreach ($tree as $menu_data) {
-    $items[] = [
-      'title' => $menu_data['title'],
-      'url' => !empty($menu_data['url']) ? $menu_data['url'] : '#',
-      'attributes' => !empty($menu_data['attributes']) ? $menu_data['attributes']->toArray() : [],
-      'active' => $menu_data['in_active_trail'],
-      'links' => $menu_data['below'] ? jcc_custom_build_menu_tree($menu_data['below']) : [],
-    ];
+    if ($menu_data['url']->toString()) {
+      $items[] = [
+        'title' => $menu_data['title'],
+        'url' => !empty($menu_data['url']) ? $menu_data['url'] : Url::fromRoute('<front>'),
+        'attributes' => !empty($menu_data['attributes']) ? $menu_data['attributes']->toArray() : [],
+        'active' => $menu_data['in_active_trail'],
+        'links' => $menu_data['below'] ? jcc_custom_build_menu_tree($menu_data['below']) : [],
+      ];
+    }
   }
 
   return $items;

--- a/web/themes/custom/jcc_elevated/includes/node.inc
+++ b/web/themes/custom/jcc_elevated/includes/node.inc
@@ -110,11 +110,6 @@ function jcc_elevated_node_subpage(array &$variables, NodeInterface $node) {
       $pid = array_key_first(array_slice($pid, -2, 1));
       $parent_menu_item = $menu_link_manager->getInstance(['id' => $pid]);
       $url = $parent_menu_item->getUrlObject();
-      $url->setOptions([
-        'attributes' => [
-          'style' => 'color: currentColor;text-decoration: none',
-        ],
-      ]);
       $parent_link = Link::fromTextAndUrl($parent_menu_item->getTitle(), $url)->toString();
       break;
     }

--- a/web/themes/custom/jcc_elevated/includes/node.inc
+++ b/web/themes/custom/jcc_elevated/includes/node.inc
@@ -120,6 +120,8 @@ function jcc_elevated_node_subpage(array &$variables, NodeInterface $node) {
       $menu_build_tree['#cache']['contexts'][] = 'user';
       $menu_build_tree['#cache']['tags'][] = 'node_list:landing_page';
       $menu_build_tree['#cache']['tags'][] = 'node_list:subpage';
+      $menu_build_tree['#cache']['tags'][] = 'node:' . $node->id();
+
       $variables['sidebar_navigation'] = [
         'menu_heading' => $parent_link,
         'links' => jcc_custom_build_menu_tree($menu_build_tree['#items']),

--- a/web/themes/custom/jcc_elevated/includes/node.inc
+++ b/web/themes/custom/jcc_elevated/includes/node.inc
@@ -5,7 +5,6 @@
  * Preprocess and functions for alert content type and component.
  */
 
-use Drupal\Core\Link;
 use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\node\NodeInterface;
 
@@ -110,7 +109,10 @@ function jcc_elevated_node_subpage(array &$variables, NodeInterface $node) {
       $pid = array_key_first(array_slice($pid, -2, 1));
       $parent_menu_item = $menu_link_manager->getInstance(['id' => $pid]);
       $url = $parent_menu_item->getUrlObject();
-      $parent_link = Link::fromTextAndUrl($parent_menu_item->getTitle(), $url)->toString();
+      $parent_link = [
+        'title' => $parent_menu_item->getTitle(),
+        'url' => $url,
+      ];
       break;
     }
 

--- a/web/themes/custom/jcc_elevated/templates/form/input--submit--search-search-submit--header.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/form/input--submit--search-search-submit--header.html.twig
@@ -10,7 +10,6 @@
  * @see template_preprocess_input()
  */
 #}
-{#style="--icon-size: 2.5rem;position: relative; width: 2.5rem; height: 2.5rem;"#}
 <button{{ attributes }}>
   <span class="header-search__search-line"></span>
   <span class="header-search__search-circle">

--- a/web/themes/custom/jcc_elevated/templates/form/input--submit--search-search-submit.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/form/input--submit--search-search-submit.html.twig
@@ -11,8 +11,8 @@
  */
 #}
 <button{{ attributes }}>
-  <span class="header-search__search-line"></span>
-  <span class="header-search__search-circle">
+  <span class='inline-form__submit-line'></span>
+  <span class='inline-form__submit-circle'></span>
   </span><span class="sr-only">Search</span>
 </button>
 

--- a/web/themes/custom/jcc_elevated/templates/node/node--subpage.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/node/node--subpage.html.twig
@@ -96,7 +96,7 @@
 
     {% if sidebar_navigation.links is not empty %}
       {% include "@molecules/SidebarNav/SidebarNav.twig" with {
-        menu_heading: sidebar_navigation.heading,
+        menu_heading: sidebar_navigation.menu_heading,
         links: sidebar_navigation.links,
       } %}
     {% endif %}

--- a/web/themes/custom/jcc_elevated/templates/node/node--subpage.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/node/node--subpage.html.twig
@@ -95,7 +95,10 @@
     {{ header }}
 
     {% if sidebar_navigation.links is not empty %}
-      {% include "@molecules/SidebarNav/SidebarNav.twig" with sidebar_navigation %}
+      {% include "@molecules/SidebarNav/SidebarNav.twig" with {
+        menu_heading: sidebar_navigation.heading,
+        links: sidebar_navigation.links,
+      } %}
     {% endif %}
 
     {% if content|without('content_moderation_control')|render is not empty %}

--- a/web/themes/custom/jcc_elevated/templates/page/page.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/page/page.html.twig
@@ -56,6 +56,7 @@
 {{ attach_library("jcc_storybook/SecondaryNav") }}
 {{ attach_library("jcc_storybook/HeaderSearch") }}
 {{ attach_library("jcc_storybook/Shoe") }}
+{{ attach_library("jcc_storybook/Button") }}
 
 <div class="layout-container">
   {% include "@molecules/Hat/Hat.twig" with {


### PR DESCRIPTION
[LWR-219]

Style and template cleanup and upgrade to storybook tag 0.53.5

Removed inline styles that were a temp fix the styles for sidebarNav header. Set the header search and search page forms to use different templates to get around a style bug. Set the button library to page node to address an odd margin/sizing issue in the non-node page header