### PR TITLE
[LWR-229] -- minor fixes and storybook update

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c54e3b56eaccdf9b5b62094bb943166",
+    "content-hash": "6cb5203aa6b68d17ec843c32752f6b33",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -15096,16 +15096,16 @@
         },
         {
             "name": "judicialcouncil/jcc_storybook",
-            "version": "0.53.6",
+            "version": "0.53.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JudicialCouncilOfCalifornia/jcc_storybook.git",
-                "reference": "c9fe68bcfbaf4cd569af060b23bf3550123ed99a"
+                "reference": "15d73bb92cc66b52f938c3bf43ae6003dbf562a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JudicialCouncilOfCalifornia/jcc_storybook/zipball/c9fe68bcfbaf4cd569af060b23bf3550123ed99a",
-                "reference": "c9fe68bcfbaf4cd569af060b23bf3550123ed99a",
+                "url": "https://api.github.com/repos/JudicialCouncilOfCalifornia/jcc_storybook/zipball/15d73bb92cc66b52f938c3bf43ae6003dbf562a8",
+                "reference": "15d73bb92cc66b52f938c3bf43ae6003dbf562a8",
                 "shasum": ""
             },
             "require": {
@@ -15132,7 +15132,7 @@
                 "issues": "https://www.courts.ca.gov/policyadmin-jc.htm",
                 "source": "https://github.com/JudicialCouncilOfCalifornia/jcc_storybook"
             },
-            "time": "2023-06-09T18:55:49+00:00"
+            "time": "2023-06-16T03:39:55+00:00"
         },
         {
             "name": "kint-php/kint",

--- a/web/themes/custom/jcc_elevated/includes/node.inc
+++ b/web/themes/custom/jcc_elevated/includes/node.inc
@@ -118,20 +118,22 @@ function jcc_elevated_node_subpage(array &$variables, NodeInterface $node) {
 
     // Get the base active trail menu parent title.
     $parent_link = NULL;
-    foreach ($menu_build_tree['#items'] as $id => $item) {
-      $pid = $menu_link_manager->getParentIds($id);
-      $pid = array_key_first(array_slice($pid, -2, 1));
-      $parent_menu_item = $menu_link_manager->getInstance(['id' => $pid]);
-      $url = $parent_menu_item->getUrlObject();
-      $parent_link = [
-        'title' => $parent_menu_item->getTitle(),
-        'url' => $url,
-      ];
-      break;
+    if (isset($menu_build_tree['#items']) && !empty($menu_build_tree['#items'])) {
+      foreach ($menu_build_tree['#items'] as $id => $item) {
+        $pid = $menu_link_manager->getParentIds($id);
+        $pid = array_key_first(array_slice($pid, -2, 1));
+        $parent_menu_item = $menu_link_manager->getInstance(['id' => $pid]);
+        $url = $parent_menu_item->getUrlObject();
+        $parent_link = [
+          'title' => $parent_menu_item->getTitle(),
+          'url' => $url,
+        ];
+        break;
+      }
     }
 
     // Create our storybook component friendly sidebar navigation.
-    if (!empty($menu_build_tree['#items'])) {
+    if (isset($menu_build_tree['#items']) && !empty($menu_build_tree['#items'])) {
       // Set caches to trigger on landing and subpage changes.
       $menu_build_tree['#cache']['contexts'][] = 'user';
       $menu_build_tree['#cache']['tags'][] = 'node_list:landing_page';

--- a/web/themes/custom/jcc_elevated/includes/node.inc
+++ b/web/themes/custom/jcc_elevated/includes/node.inc
@@ -40,6 +40,20 @@ function jcc_elevated_node_news(array &$variables, NodeInterface $node) {
 }
 
 /**
+ * Node: News preprocess.
+ *
+ * @param array $variables
+ *   The preprocess variables.
+ * @param Drupal\node\NodeInterface $node
+ *   The node.
+ */
+function jcc_elevated_node_alert(array &$variables, NodeInterface $node) {
+  // Prepend alert label directly to the body content so that it renders inline.
+  $label = '<strong>' . $node->label() . '</strong>';
+  $variables['content']['body'][0]['#text'] = $label . ', ' . $variables['content']['body'][0]['#text'];
+}
+
+/**
  * Node: Subpage preprocess.
  *
  * @param array $variables

--- a/web/themes/custom/jcc_elevated/templates/node/node--alert.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/node/node--alert.html.twig
@@ -76,7 +76,7 @@
 {% include "@molecules/Alert/Alert.twig" with {
   type: node.field_alert_type.get(0).value|default('info'),
   dismissible: node.field_toggle.get(0).value|default(false),
-  heading: label,
+  heading: '',
   content: [content.body|render],
   icon_path: base_path ~ 'themes/contrib/jcc_storybook/src/assets/icons.svg',
 } %}

--- a/web/themes/custom/jcc_elevated/templates/node/node--alert.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/node/node--alert.html.twig
@@ -78,5 +78,5 @@
   dismissible: node.field_toggle.get(0).value|default(false),
   heading: '',
   content: [content.body|render],
-  icon_path: base_path ~ 'themes/contrib/jcc_storybook/src/assets/icons.svg',
+  icon_path: url('<front>')|render ~ 'themes/contrib/jcc_storybook/src/assets/icons.svg',
 } %}

--- a/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--alert.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--alert.html.twig
@@ -6,5 +6,5 @@
   dismissible: false,
   heading: paragraph.field_heading.get(0).value,
   content: content|without('field_variant'),
-  icon_path: base_path ~ 'themes/contrib/jcc_storybook/src/assets/icons.svg',
+  icon_path: url('<front>')|render ~ 'themes/contrib/jcc_storybook/src/assets/icons.svg',
 } %}

--- a/web/themes/custom/jcc_elevated/templates/system/status-messages.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/system/status-messages.html.twig
@@ -39,7 +39,7 @@
       type: type,
       dismissible: 'true',
       content: messages,
-      icon_path: base_path ~ 'themes/contrib/jcc_storybook/src/assets/icons.svg',
+      icon_path: url('<front>')|render ~ 'themes/contrib/jcc_storybook/src/assets/icons.svg',
     } %}
 
     {% if type == 'error' %}


### PR DESCRIPTION
[LWR-229] -- minor fixes and storybook update.

Set alerts (node based in header view block) to have the heading and body text be concatenated to match the figma designs. Other paragraph and system alerts still render the same. 

Set Storybook theme to 0.53.7 tag.