### PR TITLE
[Fix] -- Disable media_directories_ui and media_directories_editor modules

### DIFF
--- a/config/config-appellate/core.extension.yml
+++ b/config/config-appellate/core.extension.yml
@@ -108,8 +108,6 @@ module:
   media: 0
   media_boxcast: 0
   media_directories: 0
-  media_directories_editor: 0
-  media_directories_ui: 0
   media_entity_download: 0
   media_entity_file_replace: 0
   media_file_delete: 0


### PR DESCRIPTION
[Fix] -- Disable media_directories_ui and media_directories_editor modules for appellate. They cause a major WSOD due to a missing route path bug.