### PR TITLE
Feature/improvements and bug fixes to jcc sections

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3be65ece34a1852fda97c1471d75bd5",
+    "content-hash": "c8df82c48f1f71846945f3fca81430bf",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -15103,16 +15103,16 @@
         },
         {
             "name": "judicialcouncil/jcc_storybook",
-            "version": "0.54.20",
+            "version": "0.54.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JudicialCouncilOfCalifornia/jcc_storybook.git",
-                "reference": "30b4e8ee49e8dddcaf7a165b2365d981cf568702"
+                "reference": "d733bf89444a32766627b9f606583fdbed2be605"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JudicialCouncilOfCalifornia/jcc_storybook/zipball/30b4e8ee49e8dddcaf7a165b2365d981cf568702",
-                "reference": "30b4e8ee49e8dddcaf7a165b2365d981cf568702",
+                "url": "https://api.github.com/repos/JudicialCouncilOfCalifornia/jcc_storybook/zipball/d733bf89444a32766627b9f606583fdbed2be605",
+                "reference": "d733bf89444a32766627b9f606583fdbed2be605",
                 "shasum": ""
             },
             "require": {
@@ -15139,7 +15139,7 @@
                 "issues": "https://www.courts.ca.gov/policyadmin-jc.htm",
                 "source": "https://github.com/JudicialCouncilOfCalifornia/jcc_storybook"
             },
-            "time": "2023-08-31T20:52:37+00:00"
+            "time": "2023-09-06T04:43:54+00:00"
         },
         {
             "name": "kint-php/kint",

--- a/config/config-diversity-toolkit/core.extension.yml
+++ b/config/config-diversity-toolkit/core.extension.yml
@@ -201,6 +201,7 @@ module:
   content_translation: 10
   views: 10
   paragraphs: 11
+  jcc_elevated_custom: 100
   jcc_components_profile: 1000
 theme:
   jcc_storybook: 0

--- a/config/config-store-front/core.extension.yml
+++ b/config/config-store-front/core.extension.yml
@@ -200,6 +200,7 @@ module:
   content_translation: 10
   views: 10
   paragraphs: 11
+  jcc_elevated_custom: 100
   jcc_components_profile: 1000
   jcc_messaging_center: 0
   email_registration: 0

--- a/web/modules/custom/jcc_custom/jcc_custom.module
+++ b/web/modules/custom/jcc_custom/jcc_custom.module
@@ -698,3 +698,18 @@ function jcc_custom_preprocess_input(&$variables) {
     }
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function jcc_custom_form_taxonomy_overview_vocabularies_alter(&$form, FormStateInterface $form_state) {
+  // Hide the "JCC Sections" vocabulary from Vocab if "jcc_elevated_sections"
+  // module is not enabled. Since the vocab config must be in the immutable
+  // feature, this will at least hide it for all sites that are not using the
+  // "JCC Sections" functionality.
+  $moduleHandler = \Drupal::service('module_handler');
+  if (!$moduleHandler->moduleExists('jcc_elevated_sections')) {
+    unset($form['vocabularies']['jcc_sections']);
+  }
+
+}

--- a/web/modules/custom/jcc_elevated_sections/jcc_elevated_sections.module
+++ b/web/modules/custom/jcc_elevated_sections/jcc_elevated_sections.module
@@ -606,10 +606,30 @@ function jcc_elevated_sections_views_pre_render(ViewExecutable $view) {
   // If we have a view that is assigned to be contextually filtered.
   if (!$is_admin && $section_service->isViewSectionable($view_name_display)) {
 
+    // Grab the filter options from the view and set a new one.
+    $filters = $view->display_handler->getOption('filters');
+
+    // Determine if the view has an exposed form. If it has an exposed form, we
+    // do not want to do any contextual filtering. The exposed form will handle
+    // that functionality.
+    $base_table = array_key_first($view->getBaseTables());
+    $jcc_section_filter_name = $base_table == 'users_field_data' ? 'jcc_sections_target_id' : 'jcc_section';
+    $view_contains_exposed_filter = FALSE;
+    foreach ($filters as $filter) {
+      // If the only filter applied is the code based jcc filter, ignore it.
+      if ($filter['id'] == $jcc_section_filter_name) {
+        continue;
+      }
+      // Look at the other filters and see if any of them are set to exposed.
+      if (isset($filter['exposed']) && $filter['exposed']) {
+        $view_contains_exposed_filter = TRUE;
+      }
+    }
+
     // Figure out the section for the current node.
     $sid = jcc_get_current_page_section();
 
-    if ($sid) {
+    if ($sid && !$view_contains_exposed_filter) {
       $results = $view->result;
       $filteredResults = [];
 
@@ -653,12 +673,11 @@ function jcc_elevated_sections_views_pre_render(ViewExecutable $view) {
       $view->total_rows = count($filteredResults);
     }
 
-    if (!$sid) {
+    if (!$sid && !$view_contains_exposed_filter) {
       $results = $view->result;
       $filteredResults = [];
 
       foreach ($results as $result) {
-
         // Find the section for each resulting entity, and if the value is
         // empty, then it is most likely general/non-sectioned content. In that
         // case we don't remove it (we just add it back to the list of items).

--- a/web/modules/custom/jcc_elevated_sections/jcc_elevated_sections.module
+++ b/web/modules/custom/jcc_elevated_sections/jcc_elevated_sections.module
@@ -200,6 +200,19 @@ function jcc_elevated_sections_form_taxonomy_term_form_alter(&$form, FormStateIn
 
     // Add custom submission that will redirect to admin page on save.
     $form['actions']['submit']['#submit'][] = '_jcc_elevated_sections_term_redirect';
+
+    // If delete is block from entity_access, print our helper message.
+    if (!$form['actions']['delete']['#access']) {
+      $message[] = t('Deleting is prevented.');
+      $message[] = t('This section has content, media, and/or users associated with it.');
+      $message[] = t('Please delete or edit that content first, to remove this section term.');
+      $form['notify'] = [
+        '#prefix' => '<p class="form-item__description">',
+        '#markup' => implode('<br/>', $message),
+        '#weight' => 101,
+        '#suffix' => '</p>',
+      ];
+    }
   }
 
   if ($term->bundle() != $vocab_source) {
@@ -551,6 +564,26 @@ function jcc_elevated_sections_entity_access(EntityInterface $entity, $operation
           return AccessResult::forbidden();
         }
       }
+    }
+  }
+
+  // When deleting the section taxonomy, prevent deletion if there is content
+  // associated with the section. Better to edit the term with a new name, or
+  // edit the content that is associated with it.
+  if ($operation == 'delete') {
+    if ($entity->getEntityTypeId() == 'taxonomy_term') {
+      $section_service = Drupal::service('jcc_elevated_sections.service');
+      $vid = $section_service->getSectionSourceId();
+      if ($entity->bundle() == $vid) {
+
+        // See if any content is associated with our section.
+        $content_ids_associated_with_the_section_term = _jcc_elevated_sections_get_all_entities_connected_to_section($entity->id());
+
+        if ($content_ids_associated_with_the_section_term) {
+          return AccessResult::forbidden();
+        }
+      }
+
     }
   }
 
@@ -944,4 +977,31 @@ function jcc_get_current_page_section() {
   }
 
   return FALSE;
+}
+
+/**
+ * Helper function to see if any content is tagged with a section.
+ *
+ * Finds all node ids, media item ids, and user ids tagged with a section term.
+ */
+function _jcc_elevated_sections_get_all_entities_connected_to_section($sid) {
+  // Get the node ids of content associated with the section term.
+  $nids = \Drupal::database()->select('node_field_data', 'n')
+    ->fields('n', ['nid'])
+    ->condition('jcc_section', $sid)
+    ->execute()->fetchCol();
+
+  // Get the media ids of media associated with the section term.
+  $mids = \Drupal::database()->select('media_field_data', 'm')
+    ->fields('m', ['mid'])
+    ->condition('jcc_section', $sid)
+    ->execute()->fetchCol();
+
+  // Get the ids of users associated with the section term.
+  $uids = \Drupal::database()->select('user__jcc_sections', 'u')
+    ->fields('u', ['entity_id'])
+    ->condition('jcc_sections_target_id', $sid)
+    ->execute()->fetchCol();
+
+  return array_merge($nids, $mids, $uids);
 }

--- a/web/modules/custom/jcc_elevated_sections/jcc_elevated_sections.module
+++ b/web/modules/custom/jcc_elevated_sections/jcc_elevated_sections.module
@@ -613,6 +613,13 @@ function jcc_elevated_sections_views_pre_render(ViewExecutable $view) {
       $results = $view->result;
       $filteredResults = [];
 
+      // Here is where we need to set the option to make a view general content
+      // inclusive (TRUE) or exclusive (FALSE). Inclusive means display content
+      // that is not sectioned, but still matches the other criteria. Exclusive
+      // means only display content that has a section set and matching.
+      // VVVVV This needs work to make dynamic.
+      $general_item_inclusive = TRUE;
+
       foreach ($results as $result) {
 
         // Find the section for each resulting entity, and if the value is
@@ -623,11 +630,22 @@ function jcc_elevated_sections_views_pre_render(ViewExecutable $view) {
         // removes Sectioned content that does not match current section
         // context.
         $result_section = $result->_entity->jcc_section->getValue();
-        if (empty($result_section)) {
-          $filteredResults[] = $result;
+
+        // If "display general content" along with section contextual content is
+        // set to true.
+        if ($general_item_inclusive) {
+          if (empty($result_section)) {
+            $filteredResults[] = $result;
+          }
+          elseif ($result_section[0]['target_id'] == $sid) {
+            $filteredResults[] = $result;
+          }
         }
-        elseif ($result_section[0]['target_id'] == $sid) {
-          $filteredResults[] = $result;
+        else {
+          // If this view should only display contextual sectioned items.
+          if ($result_section[0]['target_id'] == $sid) {
+            $filteredResults[] = $result;
+          }
         }
       }
 
@@ -674,25 +692,29 @@ function jcc_elevated_sections_views_pre_view(ViewExecutable $view, $display_id,
   // If we have a view that is assigned to be contextually filtered.
   if ($section_service->isViewSectionable($view_name_display)) {
 
+    $base_table = array_key_first($view->getBaseTables());
+    $jcc_section_filter_name = $base_table == 'users_field_data' ? 'jcc_sections_target_id' : 'jcc_section';
+
     // Grab the filter options from the view and set a new one.
     $filters = $view->display_handler->getOption('filters');
 
-    // Build out our default filter for our custom "jcc_section".
-    $filters['jcc_section'] = _jcc_elevated_sections_default_view_filter_info();
+    $enable_form_filter = FALSE;
+    foreach ($filters as $filter) {
+      if ($filter['id'] == $jcc_section_filter_name) {
+        continue;
+      }
 
-    $view->display_handler->overrideOption('filters', $filters);
-
-    if ($node = \Drupal::routeMatch()->getParameter('node')) {
-      if ($section = $section_service->getSectionForEntity($node)) {
-        if (is_object($section)) {
-
-          // Grab the filter options from the view and set a new one.
-          $filters = $view->display_handler->getOption('filters');
-          // $filters['jcc_section'] = $filter_info;
-          $view->display_handler->overrideOption('filters', $filters);
-        }
+      if (isset($filter['exposed']) && $filter['exposed']) {
+        $enable_form_filter = TRUE;
       }
     }
+
+    // Build out our default filter for our custom "jcc_section".
+    if ($enable_form_filter) {
+      $filters[$jcc_section_filter_name] = _jcc_elevated_sections_default_view_filter_info($base_table);
+    }
+
+    $view->display_handler->overrideOption('filters', $filters);
   }
 }
 
@@ -707,6 +729,9 @@ function jcc_elevated_sections_form_views_exposed_form_alter(&$form, FormStateIn
   $view_name_display = $name . ':' . $display;
   $section_service = Drupal::service('jcc_elevated_sections.service');
 
+  $base_table = array_key_first($view->getBaseTables());
+  $jcc_section_filter_name = $base_table == 'users_field_data' ? 'jcc_sections_target_id' : 'jcc_section';
+
   // Check if form has info items, which means it has an exposed form from view.
   // This is the way we check that Sectionable views with existing exposed forms
   // receive the JCC Sections exposed form element. We add 'filter-jcc_section'
@@ -714,11 +739,13 @@ function jcc_elevated_sections_form_views_exposed_form_alter(&$form, FormStateIn
   // need to remove it. This way we will know that originally this view does not
   // have a form.
   $info = $form['#info'];
-  unset($info['filter-jcc_section']);
+  unset($info['filter-' . $jcc_section_filter_name]);
   $has_exposed_form = (bool) !empty($info);
 
   // Add the section filtering if the view is assigned to have a filter.
   if ($has_exposed_form && $section_service->isViewSectionable($view_name_display)) {
+
+    $form['captcha']['#access'] = FALSE;
 
     $route = \Drupal::routeMatch()->getRouteObject();
     $is_admin = \Drupal::service('router.admin_context')->isAdminRoute($route);
@@ -730,25 +757,25 @@ function jcc_elevated_sections_form_views_exposed_form_alter(&$form, FormStateIn
         $options[$term->id()] = $term->label();
       }
 
-      $form['#info']['filter-jcc_section'] = [
-        'operator' => 'jcc_section_op',
-        'value' => 'jcc_section',
+      $form['#info']['filter-' . $jcc_section_filter_name] = [
+        'operator' => $jcc_section_filter_name . '_op',
+        'value' => $jcc_section_filter_name,
         'label' => 'Section',
         'description' => '',
       ];
 
-      $form['jcc_section'] = [
+      $form[$jcc_section_filter_name] = [
         '#type' => 'select',
         '#options' => $options,
         '#default_value' => '',
       ];
 
-      unset($form['jcc_section']['#options']['All']);
+      $form['captcha']['#access'] = FALSE;
+
+      unset($form[$jcc_section_filter_name]['#options']['All']);
     }
   }
-  else {
-    $form['jcc_section']['#access'] = FALSE;
-  }
+
 }
 
 /**
@@ -890,7 +917,7 @@ function jcc_elevated_sections_build_menu_tree(array $tree, $add_home = FALSE, $
 /**
  * Return default filter info data, needed as base for building new filters.
  */
-function _jcc_elevated_sections_default_view_filter_info(): array {
+function _jcc_elevated_sections_default_view_filter_info($table, $enable_form_filter = FALSE): array {
 
   // Build list of roles for the default "remember roles" spot.
   $role_list = [];
@@ -904,15 +931,39 @@ function _jcc_elevated_sections_default_view_filter_info(): array {
     }
   }
 
+  switch ($table) {
+    case 'users_field_data':
+      // Use a diff table for Users, but it starts from users_field_data.
+      $table = 'user__jcc_sections';
+      $field_name = 'jcc_sections_target_id';
+      $type = 'user';
+      $entity_field = 'jcc_sections';
+      break;
+
+    case 'media_field_data':
+      $table = 'media_field_data';
+      $field_name = 'jcc_section';
+      $type = 'media';
+      $entity_field = 'jcc_section';
+      break;
+
+    default:
+      $table = 'node_field_data';
+      $field_name = 'jcc_section';
+      $type = 'node';
+      $entity_field = 'jcc_section';
+      break;
+  }
+
   return [
-    'id' => 'jcc_section',
-    'table' => 'node_field_data',
-    'field' => 'jcc_section',
+    'id' => $field_name,
+    'table' => $table,
+    'field' => $field_name,
     'relationship' => 'none',
     'group_type' => 'group',
     'admin_label' => '',
-    'entity_type' => 'node',
-    'entity_field' => 'jcc_section',
+    'entity_type' => $type,
+    'entity_field' => $entity_field,
     'plugin_id' => 'numeric',
     'operator' => '=',
     'value' => [
@@ -923,14 +974,14 @@ function _jcc_elevated_sections_default_view_filter_info(): array {
     'group' => 1,
     'exposed' => TRUE,
     'expose' => [
-      'operator_id' => 'jcc_section_op',
+      'operator_id' => $field_name . '_op',
       'label' => 'Section',
       'description' => '',
       'use_operator' => FALSE,
-      'operator' => 'jcc_section_op',
+      'operator' => $field_name . '_op',
       'operator_limit_selection' => FALSE,
       'operator_list' => [],
-      'identifier' => 'jcc_section',
+      'identifier' => $field_name,
       'required' => FALSE,
       'remember' => FALSE,
       'multiple' => FALSE,

--- a/web/modules/custom/jcc_elevated_sections/jcc_elevated_sections.services.yml
+++ b/web/modules/custom/jcc_elevated_sections/jcc_elevated_sections.services.yml
@@ -1,4 +1,4 @@
 services:
   jcc_elevated_sections.service:
     class: Drupal\jcc_elevated_sections\JccSectionService
-    arguments: ['@entity_type.manager', '@current_user', '@state', '@redirect.destination']
+    arguments: [ '@entity_type.manager', '@current_user', '@state', '@redirect.destination', '@string_translation' ]

--- a/web/modules/custom/jcc_elevated_sections/src/JccSectionService.php
+++ b/web/modules/custom/jcc_elevated_sections/src/JccSectionService.php
@@ -201,13 +201,13 @@ class JccSectionService implements JccSectionServiceInterface {
     $node_types = $this->getSectionableTypes();
     if ($node_types[$type] == $type) {
       $value = $entity->get('jcc_section')->getValue();
-      return $value[0]['target_id'];
+      return $value ? $value[0]['target_id'] : FALSE;
     }
 
     $media_types = $this->getSectionableMediaTypes();
     if ($media_types[$type] == $type) {
       $value = $entity->get('jcc_section')->getValue();
-      return $value[0]['target_id'];
+      return $value ? $value[0]['target_id'] : FALSE;
     }
 
     return FALSE;

--- a/web/modules/custom/jcc_elevated_sections/src/JccSectionService.php
+++ b/web/modules/custom/jcc_elevated_sections/src/JccSectionService.php
@@ -8,6 +8,7 @@ use Drupal\Core\Routing\RedirectDestinationInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\jcc_elevated_sections\Constants\JccSectionConstants;
 use Drupal\media\MediaInterface;
 use Drupal\node\NodeInterface;
@@ -60,15 +61,19 @@ class JccSectionService implements JccSectionServiceInterface {
    *   The state manager.
    * @param \Drupal\Core\Routing\RedirectDestinationInterface $redirect_destination
    *   The redirect destination manager.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The translation service.
    */
   public function __construct(EntityTypeManagerInterface $entity_type_manager,
                               AccountInterface $currentUser,
                               StateInterface $state,
-                              RedirectDestinationInterface $redirect_destination) {
+                              RedirectDestinationInterface $redirect_destination,
+                              TranslationInterface $string_translation) {
     $this->entityTypeManager = $entity_type_manager;
     $this->currentUser = $currentUser;
     $this->state = $state;
     $this->redirectDestination = $redirect_destination;
+    $this->setStringTranslation($string_translation);
   }
 
   /**
@@ -235,6 +240,7 @@ class JccSectionService implements JccSectionServiceInterface {
   public function getSectionIds() {
     return $this->entityTypeManager->getStorage('taxonomy_term')->getQuery()
       ->condition('vid', $this->getSectionSourceId())
+      ->condition('status', TRUE)
       ->sort('weight')
       ->execute() ?? [];
   }

--- a/web/themes/custom/jcc_elevated/includes/paragraph.inc
+++ b/web/themes/custom/jcc_elevated/includes/paragraph.inc
@@ -296,10 +296,15 @@ function jcc_elevated_paragraph_hero_banner(array &$variables, ParagraphInterfac
  *   The paragraph.
  */
 function jcc_elevated_paragraph_section(array &$variables, ParagraphInterface $paragraph) {
-  if ($paragraph->get('field_media')[0]->entity && !empty($paragraph->get('field_media'))) {
-    $cover_image = $paragraph->get('field_media')[0]->entity->get('field_media_image')[0]->entity->getFileUri();
-    $image_url = ImageStyle::load('container_100_percent')->buildUrl($cover_image);
-    $variables['bckg_img_url'] = $image_url;
+  $variables['bckg_img_url'] = NULL;
+
+  if (isset($paragraph->get('field_media')[0]) && $paragraph->get('field_media')[0]->entity) {
+    foreach ($paragraph->get('field_media') as $media) {
+      $cover_image = $media->get('field_media_image')[0]->entity->getFileUri();
+      $image_url = ImageStyle::load('container_100_percent')
+        ->buildUrl($cover_image);
+      $variables['bckg_img_url'] = $image_url ?? NULL;
+    }
   }
 }
 

--- a/web/themes/custom/jcc_elevated/includes/views.inc
+++ b/web/themes/custom/jcc_elevated/includes/views.inc
@@ -413,12 +413,33 @@ function jcc_elevated_preprocess_views_mini_pager(&$variables) {
  */
 function jcc_elevated_form_views_exposed_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
   $view = $form_state->get('view');
+
   if (($view->id() == 'search') && ($view->current_display == 'search')) {
     // Remove captcha from search form.
     unset($form['captcha']);
-    // Apply the form id to the items per page element so it can be moved out.
+    // Apply the form id to the items per page element, so it can be moved out.
     $form['items_per_page']['#attributes']['form'] = $form['#id'];
   }
+
+  // Hide select form elements if their options are empty or only All/Any item.
+  foreach (Element::children($form) as $name) {
+    if (isset($form[$name]) && $form[$name]['#type'] == 'select') {
+
+      // Disable Chosen on views select items. Re-enable on items as needed.
+      $form[$name]['#attributes']['class'][] = 'chosen-disable';
+
+      // Hide select items if empty options.
+      if (empty($form[$name]['#options'])) {
+        $form[$name]['#access'] = FALSE;
+      }
+
+      // Hide if only All/Any option is available.
+      if (count($form[$name]['#options']) <= 1 && isset($form[$name]['#options']['All'])) {
+        $form[$name]['#access'] = FALSE;
+      }
+    }
+  }
+
 }
 
 /**

--- a/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--views-reference--news--sticky-list.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--views-reference--news--sticky-list.html.twig
@@ -51,24 +51,28 @@
 
 {% set teaser = {
   brow_data: {
-    part_one: row['#node'].field_news_type.0.entity.name.value,
-    part_two: row['#node'].field_date.0.value|date('M d, Y'),
+    part_one: row['#node'].field_news_type.0.entity.name.value|default(''),
+    part_two: row['#node'].field_date.0.value|date('M d, Y')|default(''),
   },
-  heading: row['#node'].title(),
-  href: nodeUri['#markup'],
-  text: excerpts[0],
+  heading: row['#node'].title()|default(''),
+  href: nodeUri['#markup']|default(''),
+  text: excerpts[0]|default(''),
 } %}
 
 {% for i in 1..3 %}
   {% set row = sticky_list[i] %}
-  {% set item = {
-    link: {
-      label: row['#node'].title(),
-      href: url('entity.node.canonical', { 'node': row['#node'].id() })|render,
-    },
-    footer: row['#node'].field_date.0.value|date('M d, Y'),
-  } %}
-  {% set list_items = list_items|merge([item]) %}
+
+  {% if row['#node'] %}
+    {% set item = {
+      link: {
+        label: row['#node'].title(),
+        href: url('entity.node.canonical', { 'node': row['#node'].id() })|render,
+      },
+      footer: row['#node'].field_date.0.value|date('M d, Y'),
+    } %}
+    {% set list_items = list_items|merge([item]) %}
+  {% endif %}
+
 {% endfor %}
 
 {% set button_data = {


### PR DESCRIPTION
Feature/improvements and bug fixes to jcc sections.

Includes:
- JCC Bulk importer update - added section assignment field option. 
- Added setup to prevent deletion of section terms if content is still tagged with those items. 
- Hide JCC Section vocabulary from other sites that don't have JCC Sections enabled.
- Improvements to auto exposed filtering for Sections
- Enabling of "jcc_elevated_custom" module for diversity-toolkit and config-store-front sites.
- Update storybook library to 0.54.21
- Alteration to views exposed forms that hides select type items if their options are empty (no options or just All/Any option)
- Fix to exposed form based views accidentally receiving extra contextual filtering from current page.
- Bug Fixes, including php warnings and notices for JCC Sections module and elevated theme.

Instructions:
- After launch, Clear caches
- Review "Content admin", "Media admin", and "People/User admin" pages and confirm that the filtering by section works (Make sure some type of content, media, and users have sections applied to them).
- Review any page with a view (that is sectioned in the Section admin) and confirm it doesn't break page (at minimum).