### PR TITLE
DCAS-148 -- Breadcrumb reposition and improvements to functionality

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06944b472b838434064c8210d15271ab",
+    "content-hash": "5b68d639160d2fb725b94cf1d03ee6df",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -15431,16 +15431,16 @@
         },
         {
             "name": "judicialcouncil/jcc_storybook",
-            "version": "0.54.31",
+            "version": "0.54.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JudicialCouncilOfCalifornia/jcc_storybook.git",
-                "reference": "f312d7257e463d5e3bb31d7d324e7ced65a127f0"
+                "reference": "c135b7298502866de015eb36b4acd6c49ec4d645"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JudicialCouncilOfCalifornia/jcc_storybook/zipball/f312d7257e463d5e3bb31d7d324e7ced65a127f0",
-                "reference": "f312d7257e463d5e3bb31d7d324e7ced65a127f0",
+                "url": "https://api.github.com/repos/JudicialCouncilOfCalifornia/jcc_storybook/zipball/c135b7298502866de015eb36b4acd6c49ec4d645",
+                "reference": "c135b7298502866de015eb36b4acd6c49ec4d645",
                 "shasum": ""
             },
             "require": {
@@ -15467,7 +15467,7 @@
                 "issues": "https://www.courts.ca.gov/policyadmin-jc.htm",
                 "source": "https://github.com/JudicialCouncilOfCalifornia/jcc_storybook"
             },
-            "time": "2023-10-06T06:09:07+00:00"
+            "time": "2023-10-13T16:06:22+00:00"
         },
         {
             "name": "kint-php/kint",

--- a/web/themes/custom/jcc_elevated/includes/system.inc
+++ b/web/themes/custom/jcc_elevated/includes/system.inc
@@ -64,12 +64,46 @@ function jcc_elevated_preprocess_breadcrumb(&$variables) {
     }
   }
 
+  $add_homepage_to_breadcrumb = TRUE;
+
+  if (function_exists('jcc_get_current_page_section') && $section_id = jcc_get_current_page_section()) {
+    // Since this is a section, do not auto add the "Home" item.
+    $add_homepage_to_breadcrumb = FALSE;
+
+    // Replace the first item with a link to the section homepage.
+    $node_manager = \Drupal::entityTypeManager()->getStorage('node');
+    $section_service = Drupal::service('jcc_elevated_sections.service');
+    $section = $section_service->getSectionInfo($section_id);
+    $section_homepage_nid = $section->jcc_section_homepage->target_id;
+    $section_homepage_node = $node_manager->load($section_homepage_nid);
+    $url = Url::fromRoute('entity.node.canonical', ['node' => $section_homepage_nid]);
+    $variables['breadcrumb'][0]['text'] = $section_homepage_node->label();
+    $variables['breadcrumb'][0]['url'] = $url->toString();
+
+    // If the last item and first item are essentially the same thing, remove
+    // the first item. This only applies for sections because the section home
+    // is duplicated on the breadcrumb because the default behavior is to add
+    // the title of the current page to the end of the breadcrumb, and we have
+    // already set the same value as the new home/start link in the breadcrumb.
+    $last = end($variables['breadcrumb']);
+    if ($variables['breadcrumb'][0]['text'] == $last['text']) {
+      unset($variables['breadcrumb'][0]);
+    }
+  }
+
   // Add homepage link to start of breadcrumb.
-  $url = Url::fromRoute('<front>');
-  array_unshift($variables['breadcrumb'], [
-    'text' => t('Home'),
-    'url' => $url->toString(),
-  ]);
+  if ($add_homepage_to_breadcrumb) {
+    $url = Url::fromRoute('<front>');
+    array_unshift($variables['breadcrumb'], [
+      'text' => t('Home'),
+      'url' => $url->toString(),
+    ]);
+  }
+
+  // Remove breadcrumb if only 1 item.
+  if (count($variables['breadcrumb']) <= 1) {
+    $variables['breadcrumb'] = [];
+  }
 
   // Since we are printing the 'Current Page Title', add the URL cache context.
   // If we don't, then we might end up with something like

--- a/web/themes/custom/jcc_elevated/templates/page/page.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/page/page.html.twig
@@ -113,21 +113,15 @@
     {{ page.messaging }}
   {% endif %}
 
-  {{ breadcrumb }}
-
-  {{ page.highlighted }}
-
-  {{ page.help }}
-
   {% if section_navigation %}
     <div class="jcc-section-navigation">
-      <div class="section box">
-        <div class="container stack">
-          {% if section_navigation.section_heading %}
+      {% if section_navigation.section_heading %}
+        <div class="section box">
+          <div class="container stack">
             <h2>{{ section_navigation.section_heading }}</h2>
-          {% endif %}
+          </div>
         </div>
-      </div>
+      {% endif %}
 
       {# Alternate section contextual nav uses the PrimaryNav alt skin #}
       {% include "@molecules/PrimaryNav/PrimaryNav.twig" with {
@@ -139,6 +133,12 @@
       } %}
     </div>
   {% endif %}
+
+  {{ breadcrumb }}
+
+  {{ page.highlighted }}
+
+  {{ page.help }}
 
   <main role="main">
     <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}


### PR DESCRIPTION
**DCAS-148**

Breadcrumb reposition and improvements to functionality (especially regarding section breadcrumbs)

- Moved breadcrumb to below the section navigation
- If current page is in a section, the "Home" link changes to be the section homepage rather than the site homepage
- Hide breadcrumb if only 1 item is output, or if on the site homepage or section homepage.

**Testing:**
- Visit the site homepage to confirm that breadcrumb doesn't display
- Visit a Section homepage (like district 1) and confirm that breadcrumb doesn't display
- Visit any page that is in a section, and confirm that the first item in breadcrumb goes to section homepage
- Any oddities in items that are output most likely results from a difference in the url patterns between parent and sub pages