### PR TITLE
DCAS-161 -- Removed caching from Judges/Justices view.

### DIFF
--- a/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/views.view.justices_judges.yml
+++ b/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/views.view.justices_judges.yml
@@ -299,7 +299,7 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
+        type: none
         options: {  }
       empty: {  }
       sorts:


### PR DESCRIPTION
DCAS-161
Removed caching from Judges/Justices view. The content is cached at the field/node level