### PR TITLE
DCAS-182 -- Update to page html titles on sectioned content

### DIFF
--- a/web/modules/custom/jcc_elevated_sections/jcc_elevated_sections.module
+++ b/web/modules/custom/jcc_elevated_sections/jcc_elevated_sections.module
@@ -485,8 +485,14 @@ function jcc_elevated_sections_preprocess_html(&$variables) {
     $sid = $section_service->getSectionForNode($node);
     $section = $section_service->getSectionInfo($sid);
     if ($section && $section->label()) {
-      $site_name = \Drupal::config('system.site')->get('name');
-      $variables['head_title']['title'] = $node->getTitle() . ' | ' . $section->label() . ' | ' . $site_name;
+      $section_homepage_nid = $section->get('jcc_section_homepage')->target_id;
+      $current_nid = $node->id();
+      // We only need to apply this to section pages that are not the section
+      // homepage.
+      if ($current_nid != $section_homepage_nid) {
+        $site_name = \Drupal::config('system.site')->get('name');
+        $variables['head_title']['title'] = $node->getTitle() . ' | ' . $section->label() . ' | ' . $site_name;
+      }
     }
   }
 }

--- a/web/modules/custom/jcc_elevated_sections/jcc_elevated_sections.module
+++ b/web/modules/custom/jcc_elevated_sections/jcc_elevated_sections.module
@@ -448,7 +448,7 @@ function jcc_elevated_sections_preprocess_page_title(&$variables) {
 }
 
 /**
- * Implements hook_preprocess_page_title().
+ * Implements hook_preprocess_preprocess_html().
  */
 function jcc_elevated_sections_preprocess_html(&$variables) {
   // Set some variables.
@@ -479,6 +479,16 @@ function jcc_elevated_sections_preprocess_html(&$variables) {
     }
   }
 
+  // If the node is a sectioned node, set the page html title to follow the
+  // pattern of "page-title | section-name | site-name".
+  if ($node = $route_match->getParameter('node')) {
+    $sid = $section_service->getSectionForNode($node);
+    $section = $section_service->getSectionInfo($sid);
+    if ($section && $section->label()) {
+      $site_name = \Drupal::config('system.site')->get('name');
+      $variables['head_title']['title'] = $node->getTitle() . ' | ' . $section->label() . ' | ' . $site_name;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
DCAS-182

Update to page html titles on sectioned content. Previous content followed the "page title | site name" template for the browser page title. This update changes the behavior to sectioned content, to add the section name in between the title and site name ( "page title | section name | site name" )