### PR TITLE
[DCAS-151] -- viewsreference update and more link override

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -313,7 +313,7 @@
         "drupal/views_daterange_filters": "^1.0.0-alpha1",
         "drupal/views_entity_form_field": "^1.0@beta",
         "drupal/views_taxonomy_term_name_depth": "^7.0.0",
-        "drupal/viewsreference": "^1.8",
+        "drupal/viewsreference": "^2.0",
         "drupal/webform": "^6.0",
         "drupal/webform_myemma": "1.0",
         "drupal/webform_translation_permissions": "^1.1",
@@ -496,6 +496,9 @@
             },
             "drupal/colorbox": {
                 "Add support for remote video media": "https://www.drupal.org/files/issues/2023-06-08/add-support-for-remote-video-media-D10-3021913-43.patch"
+            },
+            "drupal/viewsreference": {
+                "'Enable extra settings' only allows for saving of 'Pagination' and 'Argument' options": "https://git.drupalcode.org/project/viewsreference/-/merge_requests/38.patch"
             }
         },
         "installer-paths": {

--- a/composer.lock
+++ b/composer.lock
@@ -13558,57 +13558,38 @@
         },
         {
             "name": "drupal/viewsreference",
-            "version": "1.8.0",
+            "version": "2.0.0-beta7",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/viewsreference.git",
-                "reference": "8.x-1.8"
+                "reference": "8.x-2.0-beta7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/viewsreference-8.x-1.8.zip",
-                "reference": "8.x-1.8",
-                "shasum": "8dd6b3828d40f4da413f73f956da528941e2ef52"
+                "url": "https://ftp.drupal.org/files/projects/viewsreference-8.x-2.0-beta7.zip",
+                "reference": "8.x-2.0-beta7",
+                "shasum": "a1adf505b6cc7e175c548a2db52d6e26ba59a299"
             },
             "require": {
-                "drupal/core": "^8.6|^9.0",
-                "php": "^7.0|^8.0",
-                "squizlabs/php_codesniffer": "*"
+                "drupal/core": "^9.3 || ^10"
             },
             "conflict": {
                 "drupal/viewsreferennce": "*"
             },
-            "require-dev": {
-                "composer/installers": "^1.2",
-                "drupal/coder": "^8.2",
-                "drupal/core-composer-scaffold": "*",
-                "webflo/drupal-core-require-dev": "~8.5"
-            },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.8",
-                    "datestamp": "1652694596",
+                    "version": "8.x-2.0-beta7",
+                    "datestamp": "1698849225",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
                     }
-                },
-                "installer-paths": {
-                    "../build/core": [
-                        "type:drupal-core"
-                    ],
-                    "../build/modules/contrib/{$name}": [
-                        "type:drupal-module"
-                    ],
-                    "../build/themes/contrib/{$name}": [
-                        "type:drupal-theme"
-                    ]
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "authors": [
                 {
@@ -13628,14 +13609,14 @@
                     "homepage": "https://www.drupal.org/user/545912"
                 }
             ],
-            "description": "Views Reference",
+            "description": "Views reference",
             "homepage": "http://drupal.org/project/viewsreference",
             "keywords": [
                 "Drupal"
             ],
             "support": {
-                "source": "http://cgit.drupalcode.org/viewsreference",
-                "issues": "http://drupal.org/project/issues/viewsreference"
+                "source": "https://git.drupalcode.org/project/viewsreference",
+                "issues": "https://www.drupal.org/project/issues/viewsreference"
             }
         },
         {
@@ -18795,63 +18776,6 @@
             "time": "2023-06-22T14:24:00+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "shasum": ""
-            },
-            "require": {
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
-                }
-            ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
-            "keywords": [
-                "phpcs",
-                "standards",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
-            },
-            "time": "2023-02-22T23:07:41+00:00"
-        },
-        {
             "name": "stack/builder",
             "version": "v1.0.6",
             "source": {
@@ -23373,6 +23297,63 @@
             "time": "2023-10-08T07:28:08+00:00"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2023-02-22T23:07:41+00:00"
+        },
+        {
             "name": "symfony/config",
             "version": "v4.4.44",
             "source": {
@@ -23537,7 +23518,6 @@
         "drupal/ckeditor_a11ychecker": 20,
         "drupal/ckeditor_balloonpanel": 20,
         "drupal/content_access": 15,
-        "drupal/diff": 5,
         "drupal/dropzonejs": 15,
         "drupal/easy_breadcrumb": 20,
         "drupal/entity_reference_facet_link": 10,

--- a/web/modules/custom/jcc_custom/src/Plugin/ViewsReferenceSetting/JccViewsReferenceMoreLinkLabel.php
+++ b/web/modules/custom/jcc_custom/src/Plugin/ViewsReferenceSetting/JccViewsReferenceMoreLinkLabel.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\jcc_custom\Plugin\ViewsReferenceSetting;
+
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\views\ViewExecutable;
+use Drupal\viewsreference\Plugin\ViewsReferenceSettingInterface;
+
+/**
+ * The views reference setting more link override.
+ *
+ * @ViewsReferenceSetting(
+ *   id = "use_more_text",
+ *   label = @Translation("More link label"),
+ *   default_value = "",
+ * )
+ */
+class JccViewsReferenceMoreLinkLabel extends PluginBase implements ViewsReferenceSettingInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function alterFormField(array &$form_field) {
+    $form_field['#type'] = 'textfield';
+    $form_field['#title'] = $this->t('More link label');
+    $form_field['#description'] = $this->t('Override the "Read More" link label for this view.');
+    $form_field['#required'] = FALSE;
+    $form_field['#weight'] = 98;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function alterView(ViewExecutable $view, $value) {
+    if (!empty($value)) {
+      $view->display_handler->setOption('use_more_text', $value);
+    }
+  }
+
+}

--- a/web/modules/custom/jcc_custom/src/Plugin/ViewsReferenceSetting/JccViewsReferenceMoreLinkUrl.php
+++ b/web/modules/custom/jcc_custom/src/Plugin/ViewsReferenceSetting/JccViewsReferenceMoreLinkUrl.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\jcc_custom\Plugin\ViewsReferenceSetting;
+
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\views\ViewExecutable;
+use Drupal\viewsreference\Plugin\ViewsReferenceSettingInterface;
+
+/**
+ * The views reference setting more link label override.
+ *
+ * @ViewsReferenceSetting(
+ *   id = "link_display",
+ *   label = @Translation("More link url"),
+ *   default_value = "",
+ * )
+ */
+class JccViewsReferenceMoreLinkUrl extends PluginBase implements ViewsReferenceSettingInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritDoc}
+   */
+  public function alterFormField(array &$form_field) {
+    $form_field['#type'] = 'entity_autocomplete';
+    $form_field['#target_type'] = 'node';
+    $form_field['#title'] = $this->t('More link URL');
+    $form_field['#description'] = $this->t('Override the "Read More" link URL for this View. Internal or external urls are allowed.');
+    $form_field['#required'] = FALSE;
+    $form_field['#process_default_value'] = FALSE;
+    $form_field['#weight'] = 99;
+    $form_field['#attributes'] = [
+      'data-autocomplete-first-character-blacklist' => '/#?',
+    ];
+    $form_field['#element_validate'] = [
+      [
+        'Drupal\link\Plugin\Field\FieldWidget\LinkWidget',
+        'validateUriElement',
+      ],
+    ];
+
+    // Process the url for an entity or an external URL.
+    if (strpos($form_field['#default_value'], 'entity:') === 0) {
+      $value = explode('/', $form_field['#default_value']);
+      $entity_id = end($value);
+      $entity = \Drupal::entityTypeManager()->getStorage($form_field['#target_type'])->load($entity_id);
+      $form_field['#default_value'] = $entity_id ? $entity : '';
+      $form_field['#process_default_value'] = TRUE;
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function alterView(ViewExecutable $view, $value) {
+    if (!empty($value)) {
+      $view->display_handler->setOption('link_display', $value);
+    }
+  }
+
+}

--- a/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/field.field.paragraph.views_reference.field_views_reference.yml
+++ b/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/field.field.paragraph.views_reference.field_views_reference.yml
@@ -87,4 +87,9 @@ settings:
     webform_submissions: 0
     who_s_new: 0
     who_s_online: 0
+  enabled_settings:
+    use_more_text: use_more_text
+    link_display: link_display
+    argument: argument
+    title: title
 field_type: viewsreference

--- a/web/themes/custom/jcc_elevated/includes/paragraph.inc
+++ b/web/themes/custom/jcc_elevated/includes/paragraph.inc
@@ -51,12 +51,14 @@ function jcc_elevated_theme_suggestions_paragraph_alter(&$suggestions, $variable
  */
 function jcc_elevated_paragraph_views_reference(array &$variables, ParagraphInterface $paragraph) {
   // In some cases we need to pass the views results to the paragraph.
+  $ref_override = [];
+
   if (!empty($paragraph->field_views_reference)) {
     $view = $paragraph->field_views_reference->referencedEntities()[0];
     $reference = $paragraph->field_views_reference->first();
 
     $value = $reference->getValue();
-    $ref_override = $value['data'] ? unserialize($value['data']) : [];
+    $ref_override = $value['data'] ? unserialize($value['data']) : []; // phpcs:ignore
 
     $target_id = $reference->target_id;
     $display_id = $reference->display_id;

--- a/web/themes/custom/jcc_elevated/includes/paragraph.inc
+++ b/web/themes/custom/jcc_elevated/includes/paragraph.inc
@@ -8,10 +8,10 @@
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Url;
+use Drupal\image\Entity\ImageStyle;
+use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\paragraphs\ParagraphInterface;
 use Drupal\views\ViewEntityInterface;
-use Drupal\paragraphs\Entity\Paragraph;
-use Drupal\image\Entity\ImageStyle;
 
 /**
  * Implements hook_preprocess_HOOK().
@@ -54,14 +54,22 @@ function jcc_elevated_paragraph_views_reference(array &$variables, ParagraphInte
   if (!empty($paragraph->field_views_reference)) {
     $view = $paragraph->field_views_reference->referencedEntities()[0];
     $reference = $paragraph->field_views_reference->first();
+
+    $value = $reference->getValue();
+    $ref_override = $value['data'] ? unserialize($value['data']) : [];
+
     $target_id = $reference->target_id;
     $display_id = $reference->display_id;
     $function = "jcc_elevated_paragraph_views_reference_{$target_id}_{$display_id}";
   }
 
+  $variables['more']['use_more_text'] = !empty($ref_override['use_more_text']) ? $ref_override['use_more_text'] : FALSE;
+  $variables['more']['link_display'] = !empty($ref_override['link_display']) ? Url::fromUri($ref_override['link_display']) : FALSE;
+
   if (!empty($function) && function_exists($function)) {
     $function($variables, $view);
   }
+
 }
 
 /**
@@ -381,7 +389,7 @@ function jcc_elevated_paragraph_action_list(array &$variables) {
 
     $action_items[$key]['description'] = '';
     if ($action_item->hasField('field_text')) {
-      if ($text_element = $action_item->get('field_text')->getValue()) {
+      if (!empty($action_item->get('field_text')->getValue())) {
         $action_items[$key]['description'] = $action_item->field_text->view('default');
       }
     }

--- a/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--views-reference--news--sticky-list.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--views-reference--news--sticky-list.html.twig
@@ -38,7 +38,6 @@
  * @ingroup themeable
  */
 #}
-
 {{ attach_library("jcc_storybook/Section") }}
 {{ attach_library("jcc_storybook/TeaserPlusList") }}
 
@@ -49,25 +48,28 @@
 {% set row = sticky_list[0] %}
 
 {% if row['#node'] %}
+  {% set id = row['#node'].id() ?? null %}
+  {% set url = id ? url('entity.node.canonical', { 'node': id }) : '' %}
   {% set teaser = {
     brow_data: {
       part_one: row['#node'].field_news_type.0.entity.name.value|default(''),
       part_two: row['#node'].field_date.0.value|date('M d, Y')|default(''),
     },
     heading: row['#node'].title()|default(''),
-    href: url('entity.node.canonical', {'node': row['#node'].id()})|render,
+    href: url['#markup'] ?? '',
     text: excerpts[0]|default(''),
   } %}
 {% endif %}
 
 {% for i in 1..3 %}
   {% set row = sticky_list[i] %}
-
-  {% if row['#node'] %}
+  {% set id = row['#node'].id() ?? null %}
+  {% set url = id ? url('entity.node.canonical', { 'node': id }) : '' %}
+  {% if row['#node'].id() %}
     {% set item = {
       link: {
         label: row['#node'].title(),
-        href: url('entity.node.canonical', { 'node': row['#node'].id() })|render,
+        href: url['#markup'] ?? '',
       },
       footer: row['#node'].field_date.0.value|date('M d, Y'),
     } %}
@@ -77,14 +79,14 @@
 {% endfor %}
 
 {% set button_data = {
-  label: 'See all news',
-  href: news_url,
+  label: more.use_more_text is not empty ?  more.use_more_text : 'See all news',
+  href: more.link_display is not empty ? more.link_display : news_url,
   variant: "primary",
 } %}
 
 {% include "@organisms/TeaserPlusList/TeaserPlusList.twig" with {
-    heading: 'News and Announcements',
-    teaser: teaser,
-    list_items: list_items,
-    button_data: button_data,
+  heading: 'News and Announcements',
+  teaser: teaser,
+  list_items: list_items,
+  button_data: button_data,
 } %}


### PR DESCRIPTION
[DCAS - 151]

Update viewsreference module from v1 to v2.

Requires database update for all sites and a feature import to make sure the 2 new settings to override the link title and link url are enabled

Also includes some twig error message fixes on the publication twig files