### PR TITLE
[COURTS-39] -- Remove request rfp node type permissions from editor role

### DIFF
--- a/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/user.role.editor.yml
+++ b/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/user.role.editor.yml
@@ -20,7 +20,6 @@ dependencies:
     - node.type.landing_page
     - node.type.location
     - node.type.news
-    - node.type.request
     - node.type.subpage
     - taxonomy.vocabulary.department
     - taxonomy.vocabulary.division
@@ -110,7 +109,6 @@ permissions:
   - 'create news content'
   - 'create publication media'
   - 'create remote_video media'
-  - 'create request content'
   - 'create subpage content'
   - 'create url aliases'
   - 'create webform'
@@ -130,7 +128,6 @@ permissions:
   - 'delete any news content'
   - 'delete any publication media'
   - 'delete any remote_video media'
-  - 'delete any request content'
   - 'delete any subpage content'
   - 'delete any webform'
   - 'delete content translations'
@@ -153,11 +150,9 @@ permissions:
   - 'delete own menu_icons media'
   - 'delete own news content'
   - 'delete own remote_video media'
-  - 'delete own request content'
   - 'delete own subpage content'
   - 'delete own webform'
   - 'delete own webform submission'
-  - 'delete request revisions'
   - 'delete subpage revisions'
   - 'delete token'
   - 'edit any alert content'
@@ -179,7 +174,6 @@ permissions:
   - 'edit any person content'
   - 'edit any publication media'
   - 'edit any remote_video media'
-  - 'edit any request content'
   - 'edit any subpage content'
   - 'edit any webform'
   - 'edit any webform submission'
@@ -203,7 +197,6 @@ permissions:
   - 'edit own person content'
   - 'edit own publication media'
   - 'edit own remote_video media'
-  - 'edit own request content'
   - 'edit own subpage content'
   - 'edit own webform'
   - 'edit own webform submission'
@@ -226,7 +219,6 @@ permissions:
   - 'revert news revisions'
   - 'revert page revisions'
   - 'revert person revisions'
-  - 'revert request revisions'
   - 'revert subpage revisions'
   - 'schedule publishing of nodes'
   - 'skip CAPTCHA'
@@ -298,7 +290,6 @@ permissions:
   - 'view own webform submission'
   - 'view page revisions'
   - 'view person revisions'
-  - 'view request revisions'
   - 'view scheduled content'
   - 'view subpage revisions'
   - 'view the administration theme'


### PR DESCRIPTION
[COURTS-39]
Remove request rfp node type permissions from editor role. This will make it so that only the "Request manager" role (and admins) will be able to work with the Request (rfp) nodes.