### PR TITLE
[DCAS-309] -- Removed 'admin users' permission from editor roles.

### DIFF
--- a/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/user.role.editor.yml
+++ b/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/user.role.editor.yml
@@ -88,7 +88,6 @@ permissions:
   - 'administer main menu items'
   - 'administer protected pages configuration'
   - 'administer redirects'
-  - 'administer users'
   - 'administer webform element access'
   - 'assign author role'
   - 'assign editor role'


### PR DESCRIPTION
[DCAS-309]

Removed 'admin users' permission from editor roles. They should not have that ability