### PR TITLE
[COURTS-166-2] -- Allows for access unpublished functionality for rules of court related nodes

### DIFF
--- a/web/modules/custom/jcc_custom/css/gin-admin-elevated.css
+++ b/web/modules/custom/jcc_custom/css/gin-admin-elevated.css
@@ -1,0 +1,6 @@
+/* Customizations for gin admin theme */
+
+.access-unpublished-form.accordion__item .gin-table-scroll-wrapper {
+  margin-bottom: unset;
+  padding-bottom: 90px;
+}

--- a/web/modules/custom/jcc_custom/jcc_custom.libraries.yml
+++ b/web/modules/custom/jcc_custom/jcc_custom.libraries.yml
@@ -63,6 +63,11 @@ gin-elevated:
     theme:
       css/gin-elevated.css: { weight: 50 }
 
+gin-admin-elevated:
+  css:
+    theme:
+      css/gin-admin-elevated.css: { weight: 50 }
+
 admin_layout_paragraphs_edit_override:
   version: VERSION
   css:

--- a/web/modules/custom/jcc_custom/jcc_custom.module
+++ b/web/modules/custom/jcc_custom/jcc_custom.module
@@ -38,6 +38,7 @@ function jcc_custom_page_attachments(array &$attachments): void {
     // Override the layout paragraphs styling.
     // 2.0 styling is drab and hard to use.
     $attachments['#attached']['library'][] = 'jcc_custom/admin_layout_paragraphs_edit_override';
+    $attachments['#attached']['library'][] = 'jcc_custom/gin-admin-elevated';
   }
 }
 

--- a/web/modules/custom/jcc_tc2_roc_feature/jcc_tc2_roc_feature.module
+++ b/web/modules/custom/jcc_tc2_roc_feature/jcc_tc2_roc_feature.module
@@ -5,7 +5,13 @@
  * Contains jcc_tc2_roc_feature module functionality.
  */
 
+use Drupal\access_unpublished\AccessUnpublished;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultAllowed;
+use Drupal\Core\Access\AccessResultNeutral;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Session\AccountInterface;
 
 // Include all files from the inc directory.
 $includes_path = dirname(__FILE__) . '/inc/*.inc';
@@ -161,4 +167,53 @@ function jcc_tc2_roc_feature_page_attachments(&$page): void {
   if (!$is_admin) {
     $page['#attached']['library'][] = 'jcc_tc2_roc_feature/jcc-roc-custom';
   }
+}
+
+/**
+ * Implements hook_entity_access().
+ *
+ * This function is a copy of access_unpublished_entity_access(), with our own
+ * way of checking if the user is anonymous, and it is a rule related node type.
+ */
+function jcc_tc2_roc_feature_entity_access(EntityInterface $entity, $operation, AccountInterface $account): AccessResultNeutral|AccessResultAllowed {
+
+  /** @var \Drupal\access_unpublished\TokenGetter $tokenGetter */
+  $tokenGetter = \Drupal::service('access_unpublished.token_getter');
+  $bundle = $entity->getEntityType()->hasKey('bundle') ? $entity->bundle() : '';
+  $config = \Drupal::config('access_unpublished.settings');
+
+  $result = AccessResult::neutral()
+    ->addCacheContexts(['url.query_args:' . $config->get('hash_key')])
+    ->cachePerPermissions()
+    ->addCacheableDependency($config)
+    ->addCacheableDependency($entity);
+
+  $type_is_roc = $bundle == 'roc_rule' || $bundle == 'roc_rule_index';
+
+  if ($operation == 'view' &&
+    $type_is_roc &&
+    ($token = $tokenGetter->getToken()) &&
+    AccessUnpublished::applicableEntityType($entity->getEntityType()) &&
+    empty($account->getRoles(TRUE)) &&
+    !$entity->isPublished()) {
+
+    $tokens = \Drupal::entityTypeManager()->getStorage('access_token')
+      ->loadByProperties([
+        'entity_type' => $entity->getEntityType()->id(),
+        'entity_id' => $entity->id(),
+        'value' => $token,
+      ]);
+
+    if (!empty($tokens)) {
+      $tokenEntity = reset($tokens);
+      $result->addCacheableDependency($tokenEntity);
+      if (!$tokenEntity->isExpired()) {
+        $result = AccessResult::allowed()
+          ->setCacheMaxAge($tokenEntity->get('expire')->value - \Drupal::time()->getRequestTime())
+          ->inheritCacheability($result);
+      }
+    }
+  }
+
+  return $result;
 }

--- a/web/modules/custom/jcc_tc2_roc_feature/src/Access/LatestRevisionCheck.php
+++ b/web/modules/custom/jcc_tc2_roc_feature/src/Access/LatestRevisionCheck.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\jcc_tc2_roc_feature\Access;
+
+use Drupal\access_unpublished\Access\LatestRevisionCheck as ContentModerationLatestRevisionCheck;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Access check for the entity moderation tab which supports access_unpublished.
+ */
+class LatestRevisionCheck extends ContentModerationLatestRevisionCheck {
+
+  /**
+   * The decorated access check.
+   *
+   * @var \Drupal\Core\Routing\Access\AccessInterface
+   */
+  protected $accessCheck;
+
+  /**
+   * LatestRevisionCheck constructor.
+   *
+   * @param \Drupal\Core\Routing\Access\AccessInterface $access_check
+   *   Latest revision access check to decorate.
+   */
+  public function __construct(AccessInterface $access_check) {
+    $this->accessCheck = $access_check;
+  }
+
+  /**
+   * Checks that there is a pending revision available.
+   *
+   * This checker assumes the presence of an '_entity_access' requirement key
+   * in the same form as used by EntityAccessCheck.
+   *
+   * @param \Symfony\Component\Routing\Route $route
+   *   The route to check against.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The parametrized route.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The current user account.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   *
+   * @see \Drupal\Core\Entity\EntityAccessCheck
+   */
+  public function access(Route $route, RouteMatchInterface $route_match, AccountInterface $account) {
+    /** @var \Drupal\Core\Access\AccessResultInterface $access */
+    $access = $this->accessCheck->access($route, $route_match, $account);
+    $entity = $this->loadEntity($route, $route_match);
+    return $access->orIf(access_unpublished_entity_access($entity, 'view', $account))
+      ->orIf(jcc_tc2_roc_feature_entity_access($entity, 'view', $account));
+  }
+
+}

--- a/web/modules/custom/jcc_tc2_roc_feature/src/JccTc2RocFeatureServiceProvider.php
+++ b/web/modules/custom/jcc_tc2_roc_feature/src/JccTc2RocFeatureServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\jcc_tc2_roc_feature;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Drupal\jcc_tc2_roc_feature\Access\LatestRevisionCheck;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Decorates the access_unpublished.latest_revision service.
+ */
+class JccTc2RocFeatureServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+
+    // We basically are piling on top of the override/alter that access_
+    // unpublished module does. We have to alter the access method that checks
+    // if a tokenized version is ok to be looked at. We have our own check for
+    // if the user is anonymous, and it's a rule/rule_index type of node.
+    // This is from Drupal\access_unpublished\AccessUnpublishedServiceProvider
+    // with some service names adjusted. We use our LatestRevisionCheck class
+    // which extends the same access_unpublished Class.
+    if ($container->hasDefinition('access_unpublished.access_check.latest_revision')) {
+      $container->register('jcc_tc2_roc_feature.access_check.latest_revision', LatestRevisionCheck::class)
+        ->setDecoratedService('access_unpublished.access_check.latest_revision')
+        ->addArgument(new Reference('jcc_tc2_roc_feature.access_check.latest_revision.inner'))
+        ->addTag('access_check', ['applies_to' => '_content_moderation_latest_version']);
+    }
+  }
+
+}


### PR DESCRIPTION
[COURTS-166-2]

Allows for access unpublished functionality for rules of court related nodes, without having to set the rule feature as an immutable feature dependency.

Basically a service decorator/alter for the AccessUnpublished access service