### PR TITLE
[COURTS-237] -- Alert paragraphs duplicate heading fix.

### DIFF
--- a/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--alert.html.twig
+++ b/web/themes/custom/jcc_elevated/templates/paragraphs/paragraph--alert.html.twig
@@ -5,6 +5,6 @@
   type: type,
   dismissible: false,
   heading: paragraph.field_heading.get(0).value,
-  content: content|without('field_variant'),
+  content: content|without('field_variant', 'field_heading'),
   icon_path: url('<front>')|render ~ 'themes/contrib/jcc_storybook/src/assets/icons.svg',
 } %}


### PR DESCRIPTION
[COURTS-237]

Alert paragraphs duplicate heading fix.
Fix in template to remove the heading field from the general content output.