### PR TITLE
[COURTS-269] -- Add flickr to footer social media section

### DIFF
--- a/web/modules/custom/jcc_elevated_custom/jcc_elevated_custom.module
+++ b/web/modules/custom/jcc_elevated_custom/jcc_elevated_custom.module
@@ -103,6 +103,7 @@ function _jcc_elevated_custom_keys(): array {
     'jcc_elevated.social_links_rss',
     'jcc_elevated.social_links_twitter',
     'jcc_elevated.social_links_youtube',
+    'jcc_elevated.social_links_flickr',
   ];
 }
 

--- a/web/modules/custom/jcc_elevated_custom/src/Form/JccElevatedCustomFooterAdminForm.php
+++ b/web/modules/custom/jcc_elevated_custom/src/Form/JccElevatedCustomFooterAdminForm.php
@@ -80,6 +80,7 @@ class JccElevatedCustomFooterAdminForm extends FormBase {
       'social_links_rss' => $this->state->get('jcc_elevated.social_links_rss'),
       'social_links_twitter' => $this->state->get('jcc_elevated.social_links_twitter'),
       'social_links_youtube' => $this->state->get('jcc_elevated.social_links_youtube'),
+      'social_links_flickr' => $this->state->get('jcc_elevated.social_links_flickr'),
     ];
   }
 
@@ -257,6 +258,15 @@ class JccElevatedCustomFooterAdminForm extends FormBase {
         ->t('YouTube'),
       '#default_value' => $state['social_links_youtube'],
       '#placeholder' => 'https://www.youtube.com/user/[name]',
+      '#group' => 'social',
+    ];
+
+    $form['social_links_flickr'] = [
+      '#type' => 'textfield',
+      '#title' => $this
+        ->t('Flickr'),
+      '#default_value' => $state['social_links_flickr'],
+      '#placeholder' => 'https://www.flickr.com/',
       '#group' => 'social',
     ];
 

--- a/web/themes/custom/jcc_elevated/includes/page.inc
+++ b/web/themes/custom/jcc_elevated/includes/page.inc
@@ -126,6 +126,7 @@ function jcc_elevated_preprocess_page(&$variables) {
     'rss' => 'jcc_elevated.social_links_rss',
     'twitter' => 'jcc_elevated.social_links_twitter',
     'youtube' => 'jcc_elevated.social_links_youtube',
+    'flickr' => 'jcc_elevated.social_links_flickr',
   ];
 
   $frontpage_path = \Drupal::urlGenerator()->generateFromRoute('<front>', [], ['absolute' => TRUE]);


### PR DESCRIPTION
[COURTS-269] -- Add flickr to footer social media section

Flickr url field is now in the footer admin section. flickr icon already exists in the current SB icon library