### PR TITLE
[COURTS-258] -- Update to nodeaccess and access_unpublished modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,6 @@
         }
     ],
     "repositories": {
-        "lenient": {
-            "type": "composer",
-            "url": "https://packages.drupal.org/lenient"
-        },
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
@@ -155,7 +151,7 @@
         "composer/installers": "^1.9",
         "consolidation/site-process": "^4.0.0",
         "cweagans/composer-patches": "^1.7",
-        "drupal/access_unpublished": "^1.0",
+        "drupal/access_unpublished": "^1.6",
         "drupal/address": "^1.7",
         "drupal/adminimal_admin_toolbar": "^1.9",
         "drupal/adminimal_theme": "^1.5",
@@ -266,7 +262,7 @@
         "drupal/mimemail": "^1.0@alpha",
         "drupal/moderated_content_bulk_publish": "^2.0",
         "drupal/module_filter": "^3.2",
-        "drupal/nodeaccess": "^1.1",
+        "drupal/nodeaccess": "^2",
         "drupal/office_hours": "^1.11",
         "drupal/openid_connect": "^1.0@beta",
         "drupal/openid_connect_windows_aad": "^1.1",
@@ -517,7 +513,7 @@
                 "Importing CSV data by URL based off https://www.drupal.org/files/issues/2021-10-28/csv-from-url-2927126-15.patch": "patches/import_from_csv_url.patch"
             },
             "drupal/nodeaccess": {
-                "Warning: Undefined array key \"rid\" + Trying to access array offset on value of type null in nodeaccess_node_access()": "https://www.drupal.org/files/issues/2023-10-11/3357718-undefined-key-rid-11.patch"
+                "null in nodeaccess_node_access_records() & Undefined array key NodeAccessHelper": "https://www.drupal.org/files/issues/2024-02-07/3419865-03-nodeaccess_node.patch"
             },
             "drupal/scheduler": {
                 "Schedule does not work for forward pending revisions after published": "https://www.drupal.org/files/issues/2024-07-03/content-moderation-translation-scheduler-3080979-49.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -16467,16 +16467,16 @@
         },
         {
             "name": "judicialcouncil/jcc_storybook",
-            "version": "0.57.9",
+            "version": "0.57.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JudicialCouncilOfCalifornia/jcc_storybook.git",
-                "reference": "b3382e416737be6e2f264cd0ad61737599c1cab4"
+                "reference": "39475489c80abb749961b2ec2ca983d40f98b76f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JudicialCouncilOfCalifornia/jcc_storybook/zipball/b3382e416737be6e2f264cd0ad61737599c1cab4",
-                "reference": "b3382e416737be6e2f264cd0ad61737599c1cab4",
+                "url": "https://api.github.com/repos/JudicialCouncilOfCalifornia/jcc_storybook/zipball/39475489c80abb749961b2ec2ca983d40f98b76f",
+                "reference": "39475489c80abb749961b2ec2ca983d40f98b76f",
                 "shasum": ""
             },
             "require": {
@@ -16503,7 +16503,7 @@
                 "issues": "https://www.courts.ca.gov/policyadmin-jc.htm",
                 "source": "https://github.com/JudicialCouncilOfCalifornia/jcc_storybook"
             },
-            "time": "2024-11-13T11:35:07+00:00"
+            "time": "2024-11-20T00:55:58+00:00"
         },
         {
             "name": "kint-php/kint",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f760f4bf12d6f818f204563352664eb",
+    "content-hash": "49455b015ce287d0674bf77ccf8785fc",
     "packages": [
         {
             "name": "arthurkushman/query-path",
@@ -2067,20 +2067,20 @@
         },
         {
             "name": "drupal/access_unpublished",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/access_unpublished.git",
-                "reference": "8.x-1.5"
+                "reference": "8.x-1.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/access_unpublished-8.x-1.5.zip",
-                "reference": "8.x-1.5",
-                "shasum": "d2751c20f88129d553bf90a89b52373d8a3e4a84"
+                "url": "https://ftp.drupal.org/files/projects/access_unpublished-8.x-1.6.zip",
+                "reference": "8.x-1.6",
+                "shasum": "d00a19a5cb794b0683559c26c2a641e9c743054a"
             },
             "require": {
-                "drupal/core": "^9 || ^10"
+                "drupal/core": "^9.2 || ^10 || ^11"
             },
             "require-dev": {
                 "drupal/graphql": "4.x-dev"
@@ -2088,8 +2088,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.5",
-                    "datestamp": "1671641602",
+                    "version": "8.x-1.6",
+                    "datestamp": "1719701023",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2102,8 +2102,12 @@
             ],
             "authors": [
                 {
-                    "name": "chr.fritsch",
+                    "name": "chr.fritsch@gmx.net",
                     "homepage": "https://www.drupal.org/user/2103716"
+                },
+                {
+                    "name": "generalredneck",
+                    "homepage": "https://www.drupal.org/user/368854"
                 },
                 {
                     "name": "martin_klima",
@@ -10303,29 +10307,29 @@
         },
         {
             "name": "drupal/nodeaccess",
-            "version": "1.1.0",
+            "version": "2.0.0-alpha2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/nodeaccess.git",
-                "reference": "8.x-1.1"
+                "reference": "2.0.0-alpha2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/nodeaccess-8.x-1.1.zip",
-                "reference": "8.x-1.1",
-                "shasum": "a8fa5fbae6022cad920e7e9bcef73ac29ec1bf15"
+                "url": "https://ftp.drupal.org/files/projects/nodeaccess-2.0.0-alpha2.zip",
+                "reference": "2.0.0-alpha2",
+                "shasum": "535962616aa353873cb50e35b76db81532da6c9e"
             },
             "require": {
-                "drupal/core": "^8 || ^9"
+                "drupal/core": "^8.8 || ^9 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.1",
-                    "datestamp": "1634751951",
+                    "version": "2.0.0-alpha2",
+                    "datestamp": "1676128517",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -10343,16 +10347,16 @@
                     "homepage": "https://www.drupal.org/user/3569773"
                 },
                 {
+                    "name": "doxigo",
+                    "homepage": "https://www.drupal.org/user/1331334"
+                },
+                {
                     "name": "jungle",
                     "homepage": "https://www.drupal.org/user/2919723"
                 },
                 {
-                    "name": "Kushal Bansal",
+                    "name": "kushal bansal",
                     "homepage": "https://www.drupal.org/user/3478917"
-                },
-                {
-                    "name": "LeDucDuBleuet",
-                    "homepage": "https://www.drupal.org/user/103166"
                 },
                 {
                     "name": "waspper",
@@ -24341,5 +24345,5 @@
         "php": ">=8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/web/modules/custom/jcc_tc2_roc_feature/inc/preprocess.inc
+++ b/web/modules/custom/jcc_tc2_roc_feature/inc/preprocess.inc
@@ -56,9 +56,10 @@ function jcc_tc2_roc_feature_preprocess_node(array &$variables): void {
   }
 
   if ($node->bundle() == 'roc_rule') {
-    if (isset($variables['content']['body'])) {
+    if (isset($variables['content']['body'][0]['#text'])) {
       // Remove all &nbsp; items from the body content.
-      $variables['content']['body'][0]['#text'] = jcc_tc2_roc_feature_filter_nbsp($variables['content']['body'][0]['#text']);
+      $string = is_string($variables['content']['body'][0]['#text']) ? $variables['content']['body'][0]['#text'] : '';
+      $variables['content']['body'][0]['#text'] = jcc_tc2_roc_feature_filter_nbsp($string);
     }
   }
 }

--- a/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/nodeaccess.settings.yml
+++ b/web/profiles/jcc_components_profile/modules/custom/jcc_tc2_all_immutable_config/config/install/nodeaccess.settings.yml
@@ -1,1329 +1,1407 @@
-grants:
-  view: 1
-  edit: 1
-  delete: 0
-priority: 0
-preserve: 1
-alert:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
+allowed_grant_operations:
+  grant_view: true
+  grant_update: true
+  grant_delete: false
+bundles_roles_grants:
+  advisory_body:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  alert:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  arbitrator:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  case:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  custom_email:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  document:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  event:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
   facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-document:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  importer:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  invitations_to_comment:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  job:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  judge:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  landing_page:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  location:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  news:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  opinion:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  remote_hearings:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  request:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  subpage:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+  tentative_ruling:
+    anonymous:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    authenticated:
+      grant_view: 1
+      grant_update: 0
+      grant_delete: 0
+    author:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    legal_files:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    contributor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    translator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    administrator:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    tentative_rulings_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    messaging_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    facilities:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    opinions_editor:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    request_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    advisory_body_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+    itc_manager:
+      grant_view: 0
+      grant_update: 0
+      grant_delete: 0
+grants_tab_availability:
+  advisory_body: false
+  alert: false
+  arbitrator: false
+  case: false
+  custom_email: false
+  document: false
+  event: false
+  facilities: false
+  importer: false
+  invitations_to_comment: false
+  job: false
+  judge: false
+  landing_page: true
+  location: false
+  news: false
+  opinion: false
+  remote_hearings: false
+  request: false
+  subpage: true
+  tentative_ruling: false
+roles_settings:
   author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-importer:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-landing_page:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-location:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-request:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: '1'
-    grant_update: '1'
-    grant_delete: '1'
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-news:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-subpage:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-role_alias:
-  author:
-    alias: Author
-    weight: '0'
+    display_name: Author
     name: Author
-    allow: 0
-  legal_files:
-    alias: 'Legal & Files'
-    weight: '0'
-    name: 'Legal & Files'
-    allow: 0
-  editor:
-    alias: Editor
-    weight: '0'
-    name: Editor
-    allow: 0
-  manager:
-    alias: Manager
-    weight: '0'
-    name: Manager
-    allow: 0
-  translator:
-    alias: Translator
-    weight: '0'
-    name: Translator
-    allow: 0
-  administrator:
-    alias: Administrator
-    weight: '0'
-    name: Administrator
-    allow: 0
-  anonymous:
-    allow: '1'
-    alias: 'Anonymous user'
-    weight: '0'
-    name: 'Anonymous user'
-  authenticated:
-    allow: '1'
-    alias: 'Authenticated user'
-    weight: '0'
-    name: 'Authenticated user'
-  contributor:
-    alias: Contributor
-    weight: '0'
-    name: Contributor
-    allow: 0
-  tentative_rulings_editor:
-    alias: 'Tentative rulings editor'
-    weight: '0'
-    name: 'Tentative rulings editor'
-    allow: 0
-  messaging_manager:
-    alias: 'Messaging manager'
-    weight: '0'
-    name: 'Messaging manager'
-    allow: 0
-  request_manager:
-    alias: 'Solicitation request manager'
-    weight: '0'
-    name: 'Solicitation request manager'
-    allow: 0
-  rules_manager:
-    alias: 'Rules manager'
-    weight: '0'
-    name: 'Rules manager'
-    allow: 0
-  facilities:
-    alias: Facilities
-    weight: '0'
-    name: Facilities
-    allow: 0
-  opinions_editor:
-    alias: 'Opinions editor'
-    weight: '0'
-    name: 'Opinions editor'
-    allow: 0
-  itc_manager:
-    alias: 'ITC Manager'
-    name: 'ITC Manager'
     weight: 0
-    allow: 0
+    selected: false
+  legal_files:
+    display_name: 'Legal &amp; Files'
+    name: 'Legal & Files'
+    weight: 0
+    selected: false
+  editor:
+    display_name: Editor
+    name: Editor
+    weight: 0
+    selected: false
+  manager:
+    display_name: Manager
+    name: Manager
+    weight: 0
+    selected: false
+  contributor:
+    display_name: Contributor
+    name: Contributor
+    weight: 0
+    selected: false
+  translator:
+    display_name: Translator
+    name: Translator
+    weight: 0
+    selected: false
+  administrator:
+    display_name: Administrator
+    name: Administrator
+    weight: 0
+    selected: false
+  anonymous:
+    display_name: 'Anonymous user'
+    name: 'Anonymous user'
+    weight: 0
+    selected: true
+  authenticated:
+    display_name: 'Authenticated user'
+    name: 'Authenticated user'
+    weight: 0
+    selected: true
+  tentative_rulings_editor:
+    display_name: 'Tentative rulings editor'
+    name: 'Tentative rulings editor'
+    weight: 0
+    selected: false
+  messaging_manager:
+    display_name: 'Messaging manager'
+    name: 'Messaging manager'
+    weight: 0
+    selected: false
+  facilities:
+    display_name: Facilities
+    name: Facilities
+    weight: 0
+    selected: false
+  opinions_editor:
+    display_name: 'Opinions editor'
+    name: 'Opinions editor'
+    weight: 0
+    selected: false
+  request_manager:
+    display_name: 'Solicitation request manager'
+    name: 'Solicitation request manager'
+    weight: 0
+    selected: false
   advisory_body_manager:
-    alias: 'Advisory body manager'
+    display_name: 'Advisory body manager'
     name: 'Advisory body manager'
     weight: 0
-    allow: 0
-role_map:
-  author: 1
-  legal_files: 2
-  editor: 3
-  manager: 4
-  translator: 5
-  administrator: 6
-  anonymous: 7
-  authenticated: 8
-  contributor: 9
-  tentative_rulings_editor: 10
-  messaging_manager: 11
-  request_manager: 12
-  facilities: 13
-  opinions_editor: 14
-  itc_manager: 15
-allowed_types:
-  alert: 0
-  arbitrator: 0
-  case: 0
-  custom_email: 0
-  document: 0
-  facilities: 0
-  importer: 0
-  job: 0
-  judge: 0
-  landing_page: 1
-  location: 0
-  news: 0
-  opinion: 0
-  remote_hearings: 0
-  request: 0
-  roc_rule: 0
-  roc_rule_index: 0
-  subpage: 1
-  tentative_ruling: 0
-  advisory_body: 0
-  event: 0
-  invitations_to_comment: 0
-judge:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-tentative_ruling:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-custom_email:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-case:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-job:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-advisory_body:
-  anonymous:
-    grant_view: 1
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: 1
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-arbitrator:
-  anonymous:
-    grant_view: 1
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: 1
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-event:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-remote_hearings:
-  anonymous:
-    grant_view: 1
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: 1
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-facilities:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: 1
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-opinion:
-  anonymous:
-    grant_view: 1
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: 1
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-roc_rule:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: '1'
-    grant_update: '1'
-    grant_delete: '1'
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-roc_rule_index:
-  anonymous:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: '1'
-    grant_update: 0
-    grant_delete: 0
-  rules_manager:
-    grant_view: '1'
-    grant_update: '1'
-    grant_delete: '1'
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  legal_files:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  contributor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  translator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  administrator:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  tentative_rulings_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  messaging_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  facilities:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  request_manager:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-  opinions_editor:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
-invitations_to_comment:
-  anonymous:
-    grant_view: 1
-    grant_update: 0
-    grant_delete: 0
-  authenticated:
-    grant_view: 1
-    grant_update: 0
-    grant_delete: 0
-  author:
-    grant_view: 0
-    grant_update: 0
-    grant_delete: 0
+    selected: false
+  itc_manager:
+    display_name: 'ITC Manager'
+    name: 'ITC Manager'
+    weight: 0
+    selected: false


### PR DESCRIPTION
[COURTS-258]

Update to nodeaccess and access_unpublished modules

This update is to help fix a strange issue where rules, rule_indexes and potentially other content types are not saving from draft to published states (with content moderation setup). A null grant id is being passed for some reason, possibly order of operations is off for this content type, which is resulting in a wsod when saving draft revision to a published state.