### PR TITLE
Bugfix/tci 1332 to clean up the data of the byline field in news list view 

### DIFF
--- a/web/themes/custom/jcc_components/src/css/image-styles.css
+++ b/web/themes/custom/jcc_components/src/css/image-styles.css
@@ -70,3 +70,8 @@
     padding: 10px; /* Ensure good spacing */
   }
 }
+
+/* remove the vertical delim bar between date and byline */
+.jcc-date-byline__date+.jcc-date-byline__byline::before{
+  content: none;
+}

--- a/web/themes/custom/jcc_components/src/css/image-styles.css
+++ b/web/themes/custom/jcc_components/src/css/image-styles.css
@@ -71,7 +71,3 @@
   }
 }
 
-/* remove the vertical delim bar between date and byline */
-.jcc-date-byline__date+.jcc-date-byline__byline::before{
-  content: none;
-}

--- a/web/themes/custom/jcc_components/templates/node/node--news.html.twig
+++ b/web/themes/custom/jcc_components/templates/node/node--news.html.twig
@@ -87,7 +87,7 @@
           title: node.title.value,
           type: node.field_news_type.0.entity.name.value,
           date: content.field_date|render|striptags,
-          byline: content.field_byline,
+          byline: content.field_byline|striptags,
           components: components,
         }
       } %}

--- a/web/themes/custom/jcc_components/templates/node/node--news.html.twig
+++ b/web/themes/custom/jcc_components/templates/node/node--news.html.twig
@@ -87,7 +87,7 @@
           title: node.title.value,
           type: node.field_news_type.0.entity.name.value,
           date: content.field_date|render|striptags,
-          byline: content.field_byline|striptags,
+          byline: content.field_byline|render|striptags,
           components: components,
         }
       } %}


### PR DESCRIPTION
indirectly we've achieved the goal to make invisible the vertical bar image between the date time field and the byline field.