### PR TITLE
tci-1372 brought up the Building hours info field to the view

### DIFF
--- a/web/themes/custom/jcc_components/templates/node/node--location.html.twig
+++ b/web/themes/custom/jcc_components/templates/node/node--location.html.twig
@@ -221,6 +221,20 @@
       classes: []
     }
   } %}
+
+{% if content.field_building_hours_info is not empty %}
+  <section class="jcc-location__building-hours-info container">
+    <div class="jcc-location__building-hours-info-wrapper">
+      <h3 class="jcc-location__building-hours-info-label">
+        {{ 'Building hours info'|t }}
+      </h3>
+      <div class="jcc-location__building-hours-info-body">
+        {{ content.field_building_hours_info }}
+      </div>
+    </div>
+  </section>
+{% endif %}
+
 {% elseif version == 'New' %}
   {# render hero section #}
   {% include '@molecules/hero/hero.twig' with {


### PR DESCRIPTION
Please note: the only file change is required, however, not sufficient, as I  have to do this on UI as a complementary step: 
from here https://ventura.lndo.site/admin/structure/types/manage/location/display, move "Building hours info" out of from the Disabled section,  change its format to Default, and save it. 


I tried to do cex -y but that will only lead to one file (config/config-ventura/core.extension.yml) changed, and that changes is meaningless or essentially trivial, and here is diff: ```--- a/config/config-ventura/core.extension.yml
+++ b/config/config-ventura/core.extension.yml
@@ -22,9 +22,9 @@ module:
   chosen: 0
   chosen_lib: 0
   ckeditor: 0
+  ckeditor5: 0
   ckeditor_a11ychecker: 0
   ckeditor_balloonpanel: 0
-  ckeditor5: 0
   color: 0
   colorbox: 0
   colorbox_inline: 0
@@ -50,8 +50,8 @@ module:
   dynamic_page_cache: 0
   easy_breadcrumb: 0
   editor: 0
-  editoria11y: 0
   editor_advanced_link: 0
+  editoria11y: 0
   email_registration: 0
   embed: 0
   emptyparagraphkiller: 0
```

If there is any code base solution, I would like to hear.

Thanks!

Alex